### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 
 # Unreleased
 
+# 2.0.0
+
 - Remove `axios` from browser implementation in favor of native `fetch`
 - Remove support for Node.js versions earlier than 20.x.x
 - Upgraded pnpm version to 10.10.0

--- a/package.json
+++ b/package.json
@@ -70,5 +70,5 @@
     "tsup": "8.4.0",
     "typescript": "5.8.2"
   },
-  "version": "1.2.0"
+  "version": "2.0.0"
 }


### PR DESCRIPTION
# 2.0.0

- Remove `axios` from browser implementation in favor of native `fetch`
- Remove support for Node.js versions earlier than 20.x.x
- Upgraded pnpm version to 10.10.0