### PR TITLE
Make http2 optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 
 # Unreleased
 
+# 2.1.0
+
+- Make `http2` optional. Default to true
+
+# Released
+
 # 2.0.0
 
 - Remove `axios` from browser implementation in favor of native `fetch`

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -6,13 +6,13 @@ import { AptosClientRequest, AptosClientResponse } from "./types";
  * @param options
  */
 export default async function aptosClient<Res>(
-  options: AptosClientRequest,
+  options: AptosClientRequest
 ): Promise<AptosClientResponse<Res>> {
   return jsonRequest<Res>(options);
 }
 
 export async function jsonRequest<Res>(
-  options: AptosClientRequest,
+  options: AptosClientRequest
 ): Promise<AptosClientResponse<Res>> {
   const { requestUrl, requestConfig } = buildRequest(options);
 
@@ -35,7 +35,7 @@ export async function jsonRequest<Res>(
  * @param options
  */
 export async function bcsRequest(
-  options: AptosClientRequest,
+  options: AptosClientRequest
 ): Promise<AptosClientResponse<ArrayBuffer>> {
   const { requestUrl, requestConfig } = buildRequest(options);
 

--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -14,18 +14,18 @@ const cookieJar = new CookieJar();
  * @param requestOptions
  */
 export default async function aptosClient<Res>(
-  requestOptions: AptosClientRequest,
+  requestOptions: AptosClientRequest
 ): Promise<AptosClientResponse<Res>> {
   return jsonRequest<Res>(requestOptions);
 }
 
 export async function jsonRequest<Res>(
-  requestOptions: AptosClientRequest,
+  requestOptions: AptosClientRequest
 ): Promise<AptosClientResponse<Res>> {
-  const { params, method, url, headers, body } = requestOptions;
+  const { params, method, url, headers, body, http2 = true } = requestOptions;
 
   const request: OptionsOfJSONResponseBody = {
-    http2: true,
+    http2,
     searchParams: convertBigIntToString(params),
     method,
     url,
@@ -84,12 +84,12 @@ export async function jsonRequest<Res>(
  * @param requestOptions
  */
 export async function bcsRequest(
-  requestOptions: AptosClientRequest,
+  requestOptions: AptosClientRequest
 ): Promise<AptosClientResponse<Buffer>> {
-  const { params, method, url, headers, body } = requestOptions;
+  const { params, method, url, headers, body, http2 = true } = requestOptions;
 
   const request: OptionsOfBufferResponseBody = {
-    http2: true,
+    http2,
     searchParams: convertBigIntToString(params),
     method,
     url,

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,4 +15,5 @@ export type AptosClientRequest = {
   params?: any;
   headers?: any;
   overrides?: any;
+  http2?: boolean;
 };


### PR DESCRIPTION
Currently http2 is enabled by default for Node calls (in the browser it depends on the browser and the server). This blocks [bun](https://bun.com/docs) users from using our SDK, because `bun` does not support http2 and calls made through the SDK fail. 
Given that bun is very popular and was just acquired by Anthropic, this PR updates the default http2 config and makes it configurable at the client level.

So eventually users will be able to do something like

```ts
const aptosConfig = new AptosConfig({
  network: Network.DEVNET,
  clientConfig: {
    http2: false,
  },
});
```

I tested it with local aptos-client and aptos-ts-sdk builds and a bun project.