### PR TITLE
Switch to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,4 @@ jobs:
 
       - run: pnpm build
 
-      - run: pnpm publish --no-git-checks --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Remove `NPM_TOKEN` secret dependency from publish workflow
- Use npm's native OIDC trusted publishing via `id-token: write` permission
- Short-lived tokens from GitHub Actions replace long-lived npm access tokens

## Setup required on npmjs.com
Before merging, configure the trusted publisher on the package settings page:
- **CI/CD provider:** GitHub Actions
- **Organization:** aptos-labs
- **Repository:** aptos-client
- **Workflow:** publish.yml

## Test plan
- [ ] Configure trusted publisher on npmjs.com
- [ ] Merge and create a test release