### PR TITLE
Update npm before publish for OIDC scoped package fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,4 +44,6 @@ jobs:
 
       - run: pnpm build
 
+      - run: npm install -g npm@latest
+
       - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Node 20's bundled npm doesn't handle OIDC token exchange for scoped packages, returning a 404
- Add `npm install -g npm@latest` before the publish step
- Fixes [npm/cli#8678](https://github.com/npm/cli/issues/8678)

## Test plan
- [ ] Merge and re-create the v2.2.0 release