### PR TITLE
[release] 3.0.1 Fix esbuild and tsc issues across builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
 
       - run: pnpm test
 
+      - run: pnpm test:build
+
   test-deno:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 
 - **Build compatibility tests** — New `test:build` script verifies the package is consumable by downstream projects using `tsc` (with `moduleResolution` set to `bundler`, `node16`, and `nodenext`) and `esbuild` (targeting both `node` and `browser` platforms).
 
+### Changed
+
+- **`undici` dependency range** — Updated the `undici` peer and dev dependency ranges to reflect the versions validated by this release.
+
 # 3.0.0
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Aptos client will be captured in this file. This changelog is written by hand for now. It
 adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+# 3.0.1
+
+### Added
+
+- **Build compatibility tests** — New `test:build` script verifies the package is consumable by downstream projects using `tsc` (with `moduleResolution` set to `bundler`, `node16`, and `nodenext`) and `esbuild` (targeting both `node` and `browser` platforms).
+
 # 3.0.0
 
 ### Breaking Changes
@@ -30,29 +36,29 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 
 **Bundle size (JS output only):**
 
-| Entry point | v2.2.0 | v3.0.0 | Change |
-|---|---|---|---|
-| Node CJS | 7.04 KB | 6.91 KB | −0.13 KB |
-| Node ESM | 5.35 KB | 5.85 KB | +0.50 KB |
-| Browser CJS | 2.81 KB | 2.82 KB | +0.01 KB |
-| Browser ESM | 1.76 KB | 1.77 KB | +0.01 KB |
-| Fetch CJS | — | 5.58 KB | new |
-| Fetch ESM | — | 4.52 KB | new |
+| Entry point     | v2.2.0    | v3.0.0     | Change                                             |
+|-----------------|-----------|------------|----------------------------------------------------|
+| Node CJS        | 7.04 KB   | 6.91 KB    | −0.13 KB                                           |
+| Node ESM        | 5.35 KB   | 5.85 KB    | +0.50 KB                                           |
+| Browser CJS     | 2.81 KB   | 2.82 KB    | +0.01 KB                                           |
+| Browser ESM     | 1.76 KB   | 1.77 KB    | +0.01 KB                                           |
+| Fetch CJS       | —         | 5.58 KB    | new                                                |
+| Fetch ESM       | —         | 4.52 KB    | new                                                |
 | **Total dist/** | **64 KB** | **104 KB** | +40 KB (includes new fetch entry + expanded .d.ts) |
 
 **Dependencies:**
 
-| | v2.2.0 (`got`) | v3.0.0 (`undici`) |
-|---|---|---|
-| Production deps | ~47 packages (got + transitive) | 1 package (undici, optional) |
-| Non-Node runtimes | N/A (browser entry had no deps) | 0 packages |
+|                   | v2.2.0 (`got`)                  | v3.0.0 (`undici`)            |
+|-------------------|---------------------------------|------------------------------|
+| Production deps   | ~47 packages (got + transitive) | 1 package (undici, optional) |
+| Non-Node runtimes | N/A (browser entry had no deps) | 0 packages                   |
 
 **Build time:**
 
-| | v2.2.0 | v3.0.0 |
-|---|---|---|
-| Wall time | ~3.8s (sequential) | ~2.5s (parallel via tsup config) |
-| Entry points | 2 (node, browser) | 3 (node, browser, fetch) |
+|              | v2.2.0             | v3.0.0                           |
+|--------------|--------------------|----------------------------------|
+| Wall time    | ~3.8s (sequential) | ~2.5s (parallel via tsup config) |
+| Entry points | 2 (node, browser)  | 3 (node, browser, fetch)         |
 
 # Released
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "test:browser": "tsx --test --test-force-exit test/browser.test.ts",
     "test:deno": "deno test --allow-net=127.0.0.1 --allow-run=npx --allow-read=. --allow-env --unsafely-ignore-certificate-errors=127.0.0.1 test/deno.integration.ts",
     "test:bun": "bun test ./test/bun.integration.ts",
-    "test:build": "tsx --test --test-force-exit test/build.test.ts",
+    "test:build": "pnpm build && tsx --test --test-force-exit test/build.test.ts",
     "lint": "biome check",
     "lint:fix": "biome check --write",
     "fmt": "biome format --write",

--- a/package.json
+++ b/package.json
@@ -7,52 +7,54 @@
     "node": ">=22.0.0"
   },
   "exports": {
-    "deno": {
-      "types": "./dist/fetch/index.fetch.d.mts",
-      "import": "./dist/fetch/index.fetch.mjs"
-    },
-    "bun": {
-      "types": "./dist/fetch/index.fetch.d.mts",
-      "import": "./dist/fetch/index.fetch.mjs"
-    },
-    "browser": {
-      "import": {
-        "types": "./dist/browser/index.browser.d.mts",
-        "default": "./dist/browser/index.browser.mjs"
-      },
-      "require": {
-        "types": "./dist/browser/index.browser.d.ts",
-        "default": "./dist/browser/index.browser.js"
-      }
-    },
-    "react-native": {
-      "import": {
+    ".": {
+      "deno": {
         "types": "./dist/fetch/index.fetch.d.mts",
-        "default": "./dist/fetch/index.fetch.mjs"
+        "import": "./dist/fetch/index.fetch.mjs"
       },
-      "require": {
-        "types": "./dist/fetch/index.fetch.d.ts",
-        "default": "./dist/fetch/index.fetch.js"
-      }
-    },
-    "node": {
-      "import": {
-        "types": "./dist/node/index.node.d.mts",
-        "default": "./dist/node/index.node.mjs"
-      },
-      "require": {
-        "types": "./dist/node/index.node.d.ts",
-        "default": "./dist/node/index.node.js"
-      }
-    },
-    "default": {
-      "import": {
+      "bun": {
         "types": "./dist/fetch/index.fetch.d.mts",
-        "default": "./dist/fetch/index.fetch.mjs"
+        "import": "./dist/fetch/index.fetch.mjs"
       },
-      "require": {
-        "types": "./dist/fetch/index.fetch.d.ts",
-        "default": "./dist/fetch/index.fetch.js"
+      "browser": {
+        "import": {
+          "types": "./dist/browser/index.browser.d.mts",
+          "default": "./dist/browser/index.browser.mjs"
+        },
+        "require": {
+          "types": "./dist/browser/index.browser.d.ts",
+          "default": "./dist/browser/index.browser.js"
+        }
+      },
+      "react-native": {
+        "import": {
+          "types": "./dist/fetch/index.fetch.d.mts",
+          "default": "./dist/fetch/index.fetch.mjs"
+        },
+        "require": {
+          "types": "./dist/fetch/index.fetch.d.ts",
+          "default": "./dist/fetch/index.fetch.js"
+        }
+      },
+      "node": {
+        "import": {
+          "types": "./dist/node/index.node.d.mts",
+          "default": "./dist/node/index.node.mjs"
+        },
+        "require": {
+          "types": "./dist/node/index.node.d.ts",
+          "default": "./dist/node/index.node.js"
+        }
+      },
+      "default": {
+        "import": {
+          "types": "./dist/fetch/index.fetch.d.mts",
+          "default": "./dist/fetch/index.fetch.mjs"
+        },
+        "require": {
+          "types": "./dist/fetch/index.fetch.d.ts",
+          "default": "./dist/fetch/index.fetch.js"
+        }
       }
     }
   },
@@ -80,6 +82,7 @@
     "test:browser": "tsx --test --test-force-exit test/browser.test.ts",
     "test:deno": "deno test --allow-net=127.0.0.1 --allow-run=npx --allow-read=. --allow-env --unsafely-ignore-certificate-errors=127.0.0.1 test/deno.integration.ts",
     "test:bun": "bun test ./test/bun.integration.ts",
+    "test:build": "tsx --test --test-force-exit test/build.test.ts",
     "lint": "biome check",
     "lint:fix": "biome check --write",
     "fmt": "biome format --write",
@@ -101,7 +104,7 @@
     "Aptos SDK"
   ],
   "peerDependencies": {
-    "undici": "^7.22.0"
+    "undici": "^7.24.1"
   },
   "peerDependenciesMeta": {
     "undici": {
@@ -112,9 +115,10 @@
     "@biomejs/biome": "^2.4.6",
     "@types/node": "^22.19.15",
     "tsx": "^4.21.0",
+    "esbuild": "^0.27.4",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
-    "undici": "^7.22.0"
+    "undici": "^7.24.1"
   },
-  "version": "3.0.0"
+  "version": "3.0.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@types/node':
         specifier: ^22.19.15
         version: 22.19.15
+      esbuild:
+        specifier: ^0.27.4
+        version: 0.27.4
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
@@ -24,8 +27,8 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       undici:
-        specifier: ^7.22.0
-        version: 7.22.0
+        specifier: ^7.24.1
+        version: 7.24.1
 
 packages:
 
@@ -86,158 +89,158 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/aix-ppc64@0.27.3':
-    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+  '@esbuild/aix-ppc64@0.27.4':
+    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.3':
-    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+  '@esbuild/android-arm64@0.27.4':
+    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.3':
-    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+  '@esbuild/android-arm@0.27.4':
+    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.3':
-    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+  '@esbuild/android-x64@0.27.4':
+    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.3':
-    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+  '@esbuild/darwin-arm64@0.27.4':
+    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.3':
-    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+  '@esbuild/darwin-x64@0.27.4':
+    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.3':
-    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+  '@esbuild/freebsd-arm64@0.27.4':
+    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.3':
-    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+  '@esbuild/freebsd-x64@0.27.4':
+    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.3':
-    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+  '@esbuild/linux-arm64@0.27.4':
+    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.3':
-    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+  '@esbuild/linux-arm@0.27.4':
+    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.3':
-    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+  '@esbuild/linux-ia32@0.27.4':
+    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.3':
-    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+  '@esbuild/linux-loong64@0.27.4':
+    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.3':
-    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+  '@esbuild/linux-mips64el@0.27.4':
+    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.3':
-    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+  '@esbuild/linux-ppc64@0.27.4':
+    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.3':
-    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+  '@esbuild/linux-riscv64@0.27.4':
+    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.3':
-    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+  '@esbuild/linux-s390x@0.27.4':
+    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.3':
-    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+  '@esbuild/linux-x64@0.27.4':
+    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+  '@esbuild/netbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.3':
-    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+  '@esbuild/netbsd-x64@0.27.4':
+    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+  '@esbuild/openbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.3':
-    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+  '@esbuild/openbsd-x64@0.27.4':
+    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.3':
-    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+  '@esbuild/openharmony-arm64@0.27.4':
+    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.3':
-    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+  '@esbuild/sunos-x64@0.27.4':
+    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.3':
-    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+  '@esbuild/win32-arm64@0.27.4':
+    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.3':
-    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+  '@esbuild/win32-ia32@0.27.4':
+    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.3':
-    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+  '@esbuild/win32-x64@0.27.4':
+    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -496,8 +499,8 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
-  esbuild@0.27.3:
-    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+  esbuild@0.27.4:
+    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -736,8 +739,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.22.0:
-    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+  undici@7.24.1:
+    resolution: {integrity: sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA==}
     engines: {node: '>=20.18.1'}
 
   which@2.0.2:
@@ -790,82 +793,82 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.6':
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.3':
+  '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
-  '@esbuild/android-arm64@0.27.3':
+  '@esbuild/android-arm64@0.27.4':
     optional: true
 
-  '@esbuild/android-arm@0.27.3':
+  '@esbuild/android-arm@0.27.4':
     optional: true
 
-  '@esbuild/android-x64@0.27.3':
+  '@esbuild/android-x64@0.27.4':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.3':
+  '@esbuild/darwin-arm64@0.27.4':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.3':
+  '@esbuild/darwin-x64@0.27.4':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.3':
+  '@esbuild/freebsd-arm64@0.27.4':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.3':
+  '@esbuild/freebsd-x64@0.27.4':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.3':
+  '@esbuild/linux-arm64@0.27.4':
     optional: true
 
-  '@esbuild/linux-arm@0.27.3':
+  '@esbuild/linux-arm@0.27.4':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.3':
+  '@esbuild/linux-ia32@0.27.4':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.3':
+  '@esbuild/linux-loong64@0.27.4':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.3':
+  '@esbuild/linux-mips64el@0.27.4':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.3':
+  '@esbuild/linux-ppc64@0.27.4':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.3':
+  '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.3':
+  '@esbuild/linux-s390x@0.27.4':
     optional: true
 
-  '@esbuild/linux-x64@0.27.3':
+  '@esbuild/linux-x64@0.27.4':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.3':
+  '@esbuild/netbsd-arm64@0.27.4':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.3':
+  '@esbuild/netbsd-x64@0.27.4':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.3':
+  '@esbuild/openbsd-arm64@0.27.4':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.3':
+  '@esbuild/openbsd-x64@0.27.4':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.3':
+  '@esbuild/openharmony-arm64@0.27.4':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.3':
+  '@esbuild/sunos-x64@0.27.4':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.3':
+  '@esbuild/win32-arm64@0.27.4':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.3':
+  '@esbuild/win32-ia32@0.27.4':
     optional: true
 
-  '@esbuild/win32-x64@0.27.3':
+  '@esbuild/win32-x64@0.27.4':
     optional: true
 
   '@isaacs/cliui@8.0.2':
@@ -998,9 +1001,9 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  bundle-require@5.1.0(esbuild@0.27.3):
+  bundle-require@5.1.0(esbuild@0.27.4):
     dependencies:
-      esbuild: 0.27.3
+      esbuild: 0.27.4
       load-tsconfig: 0.2.5
 
   cac@6.7.14: {}
@@ -1037,34 +1040,34 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
-  esbuild@0.27.3:
+  esbuild@0.27.4:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.3
-      '@esbuild/android-arm': 0.27.3
-      '@esbuild/android-arm64': 0.27.3
-      '@esbuild/android-x64': 0.27.3
-      '@esbuild/darwin-arm64': 0.27.3
-      '@esbuild/darwin-x64': 0.27.3
-      '@esbuild/freebsd-arm64': 0.27.3
-      '@esbuild/freebsd-x64': 0.27.3
-      '@esbuild/linux-arm': 0.27.3
-      '@esbuild/linux-arm64': 0.27.3
-      '@esbuild/linux-ia32': 0.27.3
-      '@esbuild/linux-loong64': 0.27.3
-      '@esbuild/linux-mips64el': 0.27.3
-      '@esbuild/linux-ppc64': 0.27.3
-      '@esbuild/linux-riscv64': 0.27.3
-      '@esbuild/linux-s390x': 0.27.3
-      '@esbuild/linux-x64': 0.27.3
-      '@esbuild/netbsd-arm64': 0.27.3
-      '@esbuild/netbsd-x64': 0.27.3
-      '@esbuild/openbsd-arm64': 0.27.3
-      '@esbuild/openbsd-x64': 0.27.3
-      '@esbuild/openharmony-arm64': 0.27.3
-      '@esbuild/sunos-x64': 0.27.3
-      '@esbuild/win32-arm64': 0.27.3
-      '@esbuild/win32-ia32': 0.27.3
-      '@esbuild/win32-x64': 0.27.3
+      '@esbuild/aix-ppc64': 0.27.4
+      '@esbuild/android-arm': 0.27.4
+      '@esbuild/android-arm64': 0.27.4
+      '@esbuild/android-x64': 0.27.4
+      '@esbuild/darwin-arm64': 0.27.4
+      '@esbuild/darwin-x64': 0.27.4
+      '@esbuild/freebsd-arm64': 0.27.4
+      '@esbuild/freebsd-x64': 0.27.4
+      '@esbuild/linux-arm': 0.27.4
+      '@esbuild/linux-arm64': 0.27.4
+      '@esbuild/linux-ia32': 0.27.4
+      '@esbuild/linux-loong64': 0.27.4
+      '@esbuild/linux-mips64el': 0.27.4
+      '@esbuild/linux-ppc64': 0.27.4
+      '@esbuild/linux-riscv64': 0.27.4
+      '@esbuild/linux-s390x': 0.27.4
+      '@esbuild/linux-x64': 0.27.4
+      '@esbuild/netbsd-arm64': 0.27.4
+      '@esbuild/netbsd-x64': 0.27.4
+      '@esbuild/openbsd-arm64': 0.27.4
+      '@esbuild/openbsd-x64': 0.27.4
+      '@esbuild/openharmony-arm64': 0.27.4
+      '@esbuild/sunos-x64': 0.27.4
+      '@esbuild/win32-arm64': 0.27.4
+      '@esbuild/win32-ia32': 0.27.4
+      '@esbuild/win32-x64': 0.27.4
 
   fdir@6.4.3(picomatch@4.0.2):
     optionalDependencies:
@@ -1271,12 +1274,12 @@ snapshots:
 
   tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.3)
+      bundle-require: 5.1.0(esbuild@0.27.4)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.0
-      esbuild: 0.27.3
+      esbuild: 0.27.4
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
@@ -1298,7 +1301,7 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.3
+      esbuild: 0.27.4
       get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
@@ -1309,7 +1312,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.22.0: {}
+  undici@7.24.1: {}
 
   which@2.0.2:
     dependencies:

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Build compatibility tests — verify the package is consumable by different
+ * TypeScript compiler settings and bundlers.
+ *
+ * These tests create a symlink that makes the project root appear as an
+ * installed npm package, then run tsc and esbuild against consumer fixture
+ * files that import `@aptos-labs/aptos-client`.
+ *
+ * Prerequisites: the package must be built (`pnpm build`) before running.
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const FIXTURE_DIR = join(ROOT, "test", "build");
+const NODE_MODULES = join(FIXTURE_DIR, "node_modules");
+const SYMLINK = join(NODE_MODULES, "@aptos-labs", "aptos-client");
+const TSC = join(ROOT, "node_modules", ".bin", "tsc");
+const ESBUILD = join(ROOT, "node_modules", ".bin", "esbuild");
+
+function setup() {
+  mkdirSync(join(NODE_MODULES, "@aptos-labs"), { recursive: true });
+  if (!existsSync(SYMLINK)) {
+    symlinkSync(ROOT, SYMLINK, "dir");
+  }
+}
+
+function cleanup() {
+  rmSync(NODE_MODULES, { recursive: true, force: true });
+  // Remove any esbuild output
+  for (const f of ["out.js", "out.js.map"]) {
+    rmSync(join(FIXTURE_DIR, f), { force: true });
+  }
+}
+
+describe("Build compatibility", () => {
+  beforeEach(() => setup());
+  afterEach(() => cleanup());
+
+  describe("tsc", () => {
+    for (const resolution of ["bundler", "node16", "nodenext"] as const) {
+      it(`moduleResolution: ${resolution}`, () => {
+        execFileSync(TSC, ["--project", join(FIXTURE_DIR, `tsconfig.${resolution}.json`)], {
+          cwd: FIXTURE_DIR,
+          stdio: "pipe",
+          timeout: 30_000,
+        });
+      });
+    }
+  });
+
+  describe("esbuild", () => {
+    it("platform: node", () => {
+      execFileSync(
+        ESBUILD,
+        [
+          join(FIXTURE_DIR, "consumer.ts"),
+          "--bundle",
+          "--platform=node",
+          "--external:undici",
+          `--outfile=${join(FIXTURE_DIR, "out.js")}`,
+        ],
+        { cwd: ROOT, stdio: "pipe", timeout: 30_000 },
+      );
+    });
+
+    it("platform: browser", () => {
+      execFileSync(
+        ESBUILD,
+        [
+          join(FIXTURE_DIR, "consumer-browser.ts"),
+          "--bundle",
+          "--platform=browser",
+          `--outfile=${join(FIXTURE_DIR, "out.js")}`,
+        ],
+        { cwd: ROOT, stdio: "pipe", timeout: 30_000 },
+      );
+    });
+  });
+});

--- a/test/build/consumer-browser.ts
+++ b/test/build/consumer-browser.ts
@@ -1,0 +1,19 @@
+/**
+ * Consumer fixture — simulates a browser project importing this package.
+ * The browser entry point does NOT export CookieJar/CookieJarLike.
+ * Used by the esbuild browser platform test.
+ */
+import aptosClient, { bcsRequest, jsonRequest } from "@aptos-labs/aptos-client";
+
+async function _verify() {
+  const res = await aptosClient<{ chain_id: number }>({
+    url: "https://fullnode.mainnet.aptoslabs.com/v1",
+    method: "GET",
+    overrides: { WITH_CREDENTIALS: true },
+  });
+  const _status: number = res.status;
+  const _data: { chain_id: number } = res.data;
+
+  await jsonRequest<string[]>({ url: "https://example.com", method: "GET" });
+  await bcsRequest({ url: "https://example.com", method: "POST", body: {} });
+}

--- a/test/build/consumer.ts
+++ b/test/build/consumer.ts
@@ -1,0 +1,37 @@
+/**
+ * Consumer fixture — simulates an ESM Node.js project importing this package.
+ * Used by the build compatibility tests (tsc with various moduleResolution settings, esbuild node).
+ */
+import type { CookieJarLike } from "@aptos-labs/aptos-client";
+import aptosClient, { bcsRequest, CookieJar, jsonRequest } from "@aptos-labs/aptos-client";
+
+async function _verify() {
+  // Default export: generic JSON request
+  const res = await aptosClient<{ chain_id: number }>({
+    url: "https://fullnode.mainnet.aptoslabs.com/v1",
+    method: "GET",
+    params: { limit: 10, start: BigInt(0) },
+    headers: { "x-custom": "value" },
+    http2: true,
+  });
+  const _status: number = res.status;
+  const _statusText: string = res.statusText;
+  const _data: { chain_id: number } = res.data;
+
+  // Named JSON request
+  await jsonRequest<string[]>({ url: "https://example.com", method: "GET" });
+
+  // BCS request returns ArrayBuffer
+  const bcsRes = await bcsRequest({ url: "https://example.com", method: "POST", body: new Uint8Array([1, 2, 3]) });
+  const _bcsData: ArrayBuffer = bcsRes.data;
+
+  // CookieJar satisfies CookieJarLike
+  const jar: CookieJarLike = new CookieJar();
+  jar.setCookie(new URL("https://example.com"), "session=abc");
+  const cookies = jar.getCookies(new URL("https://example.com"));
+  const _name: string = cookies[0].name;
+  const _value: string = cookies[0].value;
+
+  // Per-request cookie jar
+  await aptosClient({ url: "https://example.com", method: "GET", cookieJar: jar });
+}

--- a/test/build/package.json
+++ b/test/build/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/build/tsconfig.bundler.json
+++ b/test/build/tsconfig.bundler.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022"]
+  },
+  "include": ["consumer.ts"]
+}

--- a/test/build/tsconfig.node16.json
+++ b/test/build/tsconfig.node16.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022"]
+  },
+  "include": ["consumer.ts"]
+}

--- a/test/build/tsconfig.nodenext.json
+++ b/test/build/tsconfig.nodenext.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022"]
+  },
+  "include": ["consumer.ts"]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -8,7 +8,8 @@
     "test/node.test.ts",
     "test/fetch.test.ts",
     "test/browser.test.ts",
-    "test/cookieJar.test.ts"
+    "test/cookieJar.test.ts",
+    "test/build.test.ts"
   ],
   "compilerOptions": {
     "noUnusedLocals": false,


### PR DESCRIPTION
Claude informed me that the build was messed up in the TS SDK when I used the 3.0.0 version because of how the exports were made.  This fixes it for tsc, esbuild, tsup, etc.  Adds a test for it, and updates `undici` for testing