### PR TITLE
v4.1.0: fix Node compression on HTTP/2 (got, +Codecov)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,15 @@ jobs:
           test -f dist/index.node.d.ts   || { echo "Missing dist/index.node.d.ts"; exit 1; }
           test -f dist/index.browser.d.ts || { echo "Missing dist/index.browser.d.ts"; exit 1; }
 
-      - run: pnpm test
+      - name: Run tests with coverage
+        run: pnpm coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@aa56896cf108bd10b5eb883cd1d24196da57f695 # v5.5.4
+        with:
+          files: ./coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       - run: pnpm test:build
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist/
 node_modules/
+coverage/
 .env
 .aptos
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/e
 
 # Released
 
+# 4.1.0
+
+> **Compression + HTTP/2 fix.** Versions `>= 3.0.0 < 4.1.0` are broken on Node when an origin returns a compressed response (`content-encoding: br` / `gzip` / `deflate`) — the body surfaces as a string of raw compressed bytes instead of parsed JSON, and downstream code that reads response fields gets `undefined`. The bug affected every Node caller of the Aptos fullnode (which serves brotli) and any Node caller of the indexer GraphQL endpoint when the response was large enough to trigger gzip. Upgrading to 4.1.0 restores the v2-era behavior where compressed responses are decoded transparently on both HTTP/1.1 and HTTP/2.
+
+### Changed
+
+- **Node entry point: `undici` → `got`** — The `fetch + custom undici dispatcher` shape used in v3 and v4.0 silently dropped response headers (including `set-cookie`) and never decompressed responses on HTTP/2; on HTTP/1.1 the `content-encoding` header was stripped without the bytes being decoded, leaving callers no way to detect or fix it. `got` handles decompression in its own body pipeline independent of the transport, which matches what worked in v2.
+- **`got` is a regular dependency** of `@aptos-labs/aptos-client`. Replaces `undici`. Browser, fetch, Deno, Bun, and React Native entry points are unaffected.
+- **`NODE_TLS_REJECT_UNAUTHORIZED` is now honored on HTTP/2** in the Node entry. got's H2 transport (`http2-wrapper`) does not inherit the env var on its own; we now pass it through to `https.rejectUnauthorized` so the documented Node behavior works as expected.
+
+### Fixed
+
+- **Brotli, gzip, and deflate are decoded on every transport** — both HTTP/1.1 and HTTP/2, both the JSON and BCS response paths.
+- **`set-cookie` reaches the cookie jar again** — the v3+ fetch+dispatcher path silently dropped it.
+- **HTTP/2 negotiation is observable to callers** — server-set headers like `x-aptos-*` are no longer swallowed by the dispatcher wrapper.
+
+### Tests
+
+- Added a `/compressed` test endpoint that honors `accept-encoding` and echoes what it received, plus brotli/gzip/deflate decompression tests for every entry point.
+- Recast cross-runtime `HTTP/2` tests as runtime-capability reports (assert and log what the runtime negotiates) so they remain accurate as Node, Bun, and Deno improve.
+- Confirmed Node 24+ undici-backed fetch now negotiates HTTP/2 via ALPN; recent Bun versions also negotiate H2.
+
 # 4.0.0
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![Node Version](https://img.shields.io/node/v/%40aptos-labs%2Faptos-client)
 ![NPM bundle size](https://img.shields.io/bundlephobia/min/%40aptos-labs/aptos-client)
 [![NPM Package Downloads][npm-image-downloads]][npm-url]
+[![codecov](https://codecov.io/gh/aptos-labs/aptos-client/branch/main/graph/badge.svg)](https://codecov.io/gh/aptos-labs/aptos-client)
 
 # @aptos-labs/aptos-client
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,152 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@aptos-labs/aptos-client",
+      "dependencies": {
+        "got": "^15.0.5",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "2.4.15",
+        "@types/node": "22.19.19",
+        "esbuild": "0.28.0",
+        "tsx": "4.22.2",
+        "typescript": "6.0.3",
+      },
+    },
+  },
+  "packages": {
+    "@biomejs/biome": ["@biomejs/biome@2.4.15", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.15", "@biomejs/cli-darwin-x64": "2.4.15", "@biomejs/cli-linux-arm64": "2.4.15", "@biomejs/cli-linux-arm64-musl": "2.4.15", "@biomejs/cli-linux-x64": "2.4.15", "@biomejs/cli-linux-x64-musl": "2.4.15", "@biomejs/cli-win32-arm64": "2.4.15", "@biomejs/cli-win32-x64": "2.4.15" }, "bin": { "biome": "bin/biome" } }, "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.15", "", { "os": "win32", "cpu": "x64" }, "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.0", "", { "os": "android", "cpu": "arm" }, "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.0", "", { "os": "android", "cpu": "arm64" }, "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.0", "", { "os": "android", "cpu": "x64" }, "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64" }, "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.0", "", { "os": "none", "cpu": "x64" }, "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
+
+    "@keyv/serialize": ["@keyv/serialize@1.1.1", "", {}, "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA=="],
+
+    "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
+
+    "@sindresorhus/is": ["@sindresorhus/is@8.1.0", "", {}, "sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ=="],
+
+    "@types/http-cache-semantics": ["@types/http-cache-semantics@4.2.0", "", {}, "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q=="],
+
+    "@types/node": ["@types/node@22.19.19", "", { "dependencies": { "undici-types": "6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
+
+    "byte-counter": ["byte-counter@0.1.0", "", {}, "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ=="],
+
+    "cacheable-lookup": ["cacheable-lookup@7.0.0", "", {}, "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w=="],
+
+    "cacheable-request": ["cacheable-request@13.0.19", "", { "dependencies": { "@types/http-cache-semantics": "4.2.0", "get-stream": "9.0.1", "http-cache-semantics": "4.2.0", "keyv": "5.6.0", "mimic-response": "4.0.0", "normalize-url": "8.1.1", "responselike": "4.0.2" } }, "sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg=="],
+
+    "chunk-data": ["chunk-data@0.1.0", "", {}, "sha512-zFyPtyC0SZ6Zu79b9sOYtXZcgrsXe0RpePrzRyj52hYVFG1+Rk6rBqjjOEk+GNQwc3PIX+86teQMok970pod1g=="],
+
+    "decompress-response": ["decompress-response@10.0.0", "", { "dependencies": { "mimic-response": "4.0.0" } }, "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q=="],
+
+    "esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "0.4.1", "is-stream": "4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
+
+    "got": ["got@15.0.5", "", { "dependencies": { "@sindresorhus/is": "8.1.0", "byte-counter": "0.1.0", "cacheable-lookup": "7.0.0", "cacheable-request": "13.0.19", "chunk-data": "0.1.0", "decompress-response": "10.0.0", "http2-wrapper": "2.2.1", "keyv": "5.6.0", "lowercase-keys": "4.0.1", "responselike": "4.0.2", "type-fest": "5.6.0", "uint8array-extras": "1.5.0" } }, "sha512-PMIMaZuYUCK43+Z9JWEXea4kkX2b3301m81D5TS6QpfG4PmNyirzEdO/Oa2OHAN4GsjnPfvWCWsshKN2rq4/gQ=="],
+
+    "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
+
+    "http2-wrapper": ["http2-wrapper@2.2.1", "", { "dependencies": { "quick-lru": "5.1.1", "resolve-alpn": "1.2.1" } }, "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ=="],
+
+    "is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
+
+    "keyv": ["keyv@5.6.0", "", { "dependencies": { "@keyv/serialize": "1.1.1" } }, "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw=="],
+
+    "lowercase-keys": ["lowercase-keys@4.0.1", "", {}, "sha512-wI9Nui/L8VfADa/cr/7NQruaASk1k23/Uh1khQ02BCVYiiy8F4AhOGnQzJy3Fl/c44GnYSbZHv8g7EcG3kJ1Qg=="],
+
+    "mimic-response": ["mimic-response@4.0.0", "", {}, "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg=="],
+
+    "normalize-url": ["normalize-url@8.1.1", "", {}, "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ=="],
+
+    "quick-lru": ["quick-lru@5.1.1", "", {}, "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="],
+
+    "resolve-alpn": ["resolve-alpn@1.2.1", "", {}, "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="],
+
+    "responselike": ["responselike@4.0.2", "", { "dependencies": { "lowercase-keys": "3.0.0" } }, "sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA=="],
+
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
+    "tsx": ["tsx@4.22.2", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-6w9FwtT8WQqRAyTNR+Z+86kghRqpmOLjXUrBlBT6T+CQGDuIMm0VmAqaFUFBIeKDTGobE6/YSigZYLeomzBaRg=="],
+
+    "type-fest": ["type-fest@5.6.0", "", { "dependencies": { "tagged-tag": "1.0.0" } }, "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "responselike/lowercase-keys": ["lowercase-keys@3.0.0", "", {}, "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ=="],
+  }
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+# Codecov configuration — https://docs.codecov.com/docs/codecov-yaml
+#
+# Coverage goals:
+#  - Project (overall): >= 80% line coverage with a 2% drop tolerance.
+#  - Patch (changed lines in a PR): >= 80% of new/changed lines covered.
+#
+# These thresholds match the bar set when reverting the Node entry to `got`
+# in 4.1.0 (see CHANGELOG); the suite ships at ~99% line / ~94% branch and
+# we want regressions caught before they merge.
+
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 2%
+        if_ci_failed: error
+    patch:
+      default:
+        target: 80%
+        if_ci_failed: error
+
+# Only report on source — tests and build artifacts shouldn't count.
+ignore:
+  - "test/**"
+  - "dist/**"
+  - "**/*.d.ts"
+
+# Disable the per-PR comment to keep noise low — the status check above
+# enforces the gates, and the dashboard always has the full report.
+comment: false

--- a/deno.lock
+++ b/deno.lock
@@ -2,7 +2,13 @@
   "version": "5",
   "specifiers": {
     "jsr:@std/assert@*": "1.0.19",
-    "jsr:@std/internal@^1.0.12": "1.0.12"
+    "jsr:@std/internal@^1.0.12": "1.0.12",
+    "npm:@biomejs/biome@2.4.15": "2.4.15",
+    "npm:@types/node@^22.19.19": "22.19.19",
+    "npm:esbuild@0.28": "0.28.0",
+    "npm:got@^15.0.5": "15.0.5",
+    "npm:tsx@^4.22.3": "4.22.3",
+    "npm:typescript@^6.0.3": "6.0.3"
   },
   "jsr": {
     "@std/assert@1.0.19": {
@@ -15,14 +21,380 @@
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     }
   },
+  "npm": {
+    "@biomejs/biome@2.4.15": {
+      "integrity": "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==",
+      "optionalDependencies": [
+        "@biomejs/cli-darwin-arm64",
+        "@biomejs/cli-darwin-x64",
+        "@biomejs/cli-linux-arm64",
+        "@biomejs/cli-linux-arm64-musl",
+        "@biomejs/cli-linux-x64",
+        "@biomejs/cli-linux-x64-musl",
+        "@biomejs/cli-win32-arm64",
+        "@biomejs/cli-win32-x64"
+      ],
+      "bin": true
+    },
+    "@biomejs/cli-darwin-arm64@2.4.15": {
+      "integrity": "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@biomejs/cli-darwin-x64@2.4.15": {
+      "integrity": "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@biomejs/cli-linux-arm64-musl@2.4.15": {
+      "integrity": "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@biomejs/cli-linux-arm64@2.4.15": {
+      "integrity": "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@biomejs/cli-linux-x64-musl@2.4.15": {
+      "integrity": "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@biomejs/cli-linux-x64@2.4.15": {
+      "integrity": "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@biomejs/cli-win32-arm64@2.4.15": {
+      "integrity": "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@biomejs/cli-win32-x64@2.4.15": {
+      "integrity": "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/aix-ppc64@0.28.0": {
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "os": ["aix"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/android-arm64@0.28.0": {
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/android-arm@0.28.0": {
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "os": ["android"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/android-x64@0.28.0": {
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "os": ["android"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/darwin-arm64@0.28.0": {
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/darwin-x64@0.28.0": {
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/freebsd-arm64@0.28.0": {
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/freebsd-x64@0.28.0": {
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/linux-arm64@0.28.0": {
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/linux-arm@0.28.0": {
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/linux-ia32@0.28.0": {
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/linux-loong64@0.28.0": {
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
+    },
+    "@esbuild/linux-mips64el@0.28.0": {
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "os": ["linux"],
+      "cpu": ["mips64el"]
+    },
+    "@esbuild/linux-ppc64@0.28.0": {
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/linux-riscv64@0.28.0": {
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@esbuild/linux-s390x@0.28.0": {
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@esbuild/linux-x64@0.28.0": {
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/netbsd-arm64@0.28.0": {
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "os": ["netbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/netbsd-x64@0.28.0": {
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "os": ["netbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/openbsd-arm64@0.28.0": {
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "os": ["openbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/openbsd-x64@0.28.0": {
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "os": ["openbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/openharmony-arm64@0.28.0": {
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "os": ["openharmony"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/sunos-x64@0.28.0": {
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "os": ["sunos"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/win32-arm64@0.28.0": {
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/win32-ia32@0.28.0": {
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/win32-x64@0.28.0": {
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@keyv/serialize@1.1.1": {
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA=="
+    },
+    "@sec-ant/readable-stream@0.4.1": {
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
+    },
+    "@sindresorhus/is@8.1.0": {
+      "integrity": "sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ=="
+    },
+    "@types/http-cache-semantics@4.2.0": {
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q=="
+    },
+    "@types/node@22.19.19": {
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
+    "byte-counter@0.1.0": {
+      "integrity": "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ=="
+    },
+    "cacheable-lookup@7.0.0": {
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w=="
+    },
+    "cacheable-request@13.0.19": {
+      "integrity": "sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==",
+      "dependencies": [
+        "@types/http-cache-semantics",
+        "get-stream",
+        "http-cache-semantics",
+        "keyv",
+        "mimic-response",
+        "normalize-url",
+        "responselike"
+      ]
+    },
+    "chunk-data@0.1.0": {
+      "integrity": "sha512-zFyPtyC0SZ6Zu79b9sOYtXZcgrsXe0RpePrzRyj52hYVFG1+Rk6rBqjjOEk+GNQwc3PIX+86teQMok970pod1g=="
+    },
+    "decompress-response@10.0.0": {
+      "integrity": "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==",
+      "dependencies": [
+        "mimic-response"
+      ]
+    },
+    "esbuild@0.28.0": {
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "optionalDependencies": [
+        "@esbuild/aix-ppc64",
+        "@esbuild/android-arm",
+        "@esbuild/android-arm64",
+        "@esbuild/android-x64",
+        "@esbuild/darwin-arm64",
+        "@esbuild/darwin-x64",
+        "@esbuild/freebsd-arm64",
+        "@esbuild/freebsd-x64",
+        "@esbuild/linux-arm",
+        "@esbuild/linux-arm64",
+        "@esbuild/linux-ia32",
+        "@esbuild/linux-loong64",
+        "@esbuild/linux-mips64el",
+        "@esbuild/linux-ppc64",
+        "@esbuild/linux-riscv64",
+        "@esbuild/linux-s390x",
+        "@esbuild/linux-x64",
+        "@esbuild/netbsd-arm64",
+        "@esbuild/netbsd-x64",
+        "@esbuild/openbsd-arm64",
+        "@esbuild/openbsd-x64",
+        "@esbuild/openharmony-arm64",
+        "@esbuild/sunos-x64",
+        "@esbuild/win32-arm64",
+        "@esbuild/win32-ia32",
+        "@esbuild/win32-x64"
+      ],
+      "scripts": true,
+      "bin": true
+    },
+    "fsevents@2.3.3": {
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "os": ["darwin"],
+      "scripts": true
+    },
+    "get-stream@9.0.1": {
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dependencies": [
+        "@sec-ant/readable-stream",
+        "is-stream"
+      ]
+    },
+    "got@15.0.5": {
+      "integrity": "sha512-PMIMaZuYUCK43+Z9JWEXea4kkX2b3301m81D5TS6QpfG4PmNyirzEdO/Oa2OHAN4GsjnPfvWCWsshKN2rq4/gQ==",
+      "dependencies": [
+        "@sindresorhus/is",
+        "byte-counter",
+        "cacheable-lookup",
+        "cacheable-request",
+        "chunk-data",
+        "decompress-response",
+        "http2-wrapper",
+        "keyv",
+        "lowercase-keys@4.0.1",
+        "responselike",
+        "type-fest",
+        "uint8array-extras"
+      ]
+    },
+    "http-cache-semantics@4.2.0": {
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="
+    },
+    "http2-wrapper@2.2.1": {
+      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+      "dependencies": [
+        "quick-lru",
+        "resolve-alpn"
+      ]
+    },
+    "is-stream@4.0.1": {
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="
+    },
+    "keyv@5.6.0": {
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dependencies": [
+        "@keyv/serialize"
+      ]
+    },
+    "lowercase-keys@3.0.0": {
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ=="
+    },
+    "lowercase-keys@4.0.1": {
+      "integrity": "sha512-wI9Nui/L8VfADa/cr/7NQruaASk1k23/Uh1khQ02BCVYiiy8F4AhOGnQzJy3Fl/c44GnYSbZHv8g7EcG3kJ1Qg=="
+    },
+    "mimic-response@4.0.0": {
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg=="
+    },
+    "normalize-url@8.1.1": {
+      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ=="
+    },
+    "quick-lru@5.1.1": {
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
+    },
+    "resolve-alpn@1.2.1": {
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+    },
+    "responselike@4.0.2": {
+      "integrity": "sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==",
+      "dependencies": [
+        "lowercase-keys@3.0.0"
+      ]
+    },
+    "tagged-tag@1.0.0": {
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="
+    },
+    "tsx@4.22.3": {
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dependencies": [
+        "esbuild"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "bin": true
+    },
+    "type-fest@5.6.0": {
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "dependencies": [
+        "tagged-tag"
+      ]
+    },
+    "typescript@6.0.3": {
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "bin": true
+    },
+    "uint8array-extras@1.5.0": {
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="
+    },
+    "undici-types@6.21.0": {
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+    }
+  },
   "workspace": {
     "packageJson": {
       "dependencies": [
-        "npm:@biomejs/biome@^2.4.6",
-        "npm:@types/node@^22.19.15",
-        "npm:tsup@^8.5.1",
-        "npm:tsx@^4.21.0",
-        "npm:typescript@^5.9.3"
+        "npm:@biomejs/biome@2.4.15",
+        "npm:@types/node@^22.19.19",
+        "npm:esbuild@0.28",
+        "npm:got@^15.0.5",
+        "npm:tsx@^4.22.3",
+        "npm:typescript@^6.0.3"
       ]
     }
   }

--- a/deno.lock
+++ b/deno.lock
@@ -4,11 +4,11 @@
     "jsr:@std/assert@*": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "npm:@biomejs/biome@2.4.15": "2.4.15",
-    "npm:@types/node@^22.19.19": "22.19.19",
-    "npm:esbuild@0.28": "0.28.0",
+    "npm:@types/node@22.19.19": "22.19.19",
+    "npm:esbuild@0.28.0": "0.28.0",
     "npm:got@^15.0.5": "15.0.5",
-    "npm:tsx@^4.22.3": "4.22.3",
-    "npm:typescript@^6.0.3": "6.0.3"
+    "npm:tsx@4.22.2": "4.22.2",
+    "npm:typescript@6.0.3": "6.0.3"
   },
   "jsr": {
     "@std/assert@1.0.19": {
@@ -359,8 +359,8 @@
     "tagged-tag@1.0.0": {
       "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="
     },
-    "tsx@4.22.3": {
-      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+    "tsx@4.22.2": {
+      "integrity": "sha512-6w9FwtT8WQqRAyTNR+Z+86kghRqpmOLjXUrBlBT6T+CQGDuIMm0VmAqaFUFBIeKDTGobE6/YSigZYLeomzBaRg==",
       "dependencies": [
         "esbuild"
       ],
@@ -390,11 +390,11 @@
     "packageJson": {
       "dependencies": [
         "npm:@biomejs/biome@2.4.15",
-        "npm:@types/node@^22.19.19",
-        "npm:esbuild@0.28",
+        "npm:@types/node@22.19.19",
+        "npm:esbuild@0.28.0",
         "npm:got@^15.0.5",
-        "npm:tsx@^4.22.3",
-        "npm:typescript@^6.0.3"
+        "npm:tsx@4.22.2",
+        "npm:typescript@6.0.3"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -85,10 +85,10 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.15",
-    "@types/node": "^22.19.19",
-    "esbuild": "^0.28.0",
-    "tsx": "^4.22.3",
-    "typescript": "^6.0.3"
+    "@types/node": "22.19.19",
+    "esbuild": "0.28.0",
+    "tsx": "4.22.2",
+    "typescript": "6.0.3"
   },
   "version": "4.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -80,14 +80,14 @@
     "Aptos SDK"
   ],
   "dependencies": {
-    "undici": "^7.25.0"
+    "got": "^15.0.5"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.6",
-    "@types/node": "^22.19.17",
+    "@biomejs/biome": "2.4.15",
+    "@types/node": "^22.19.19",
     "esbuild": "^0.28.0",
-    "tsx": "^4.21.0",
-    "typescript": "^6.0.2"
+    "tsx": "^4.22.3",
+    "typescript": "^6.0.3"
   },
-  "version": "4.0.0"
+  "version": "4.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "build:clean": "rm -rf dist",
     "build": "pnpm build:clean && tsc --project tsconfig.build.json",
     "test": "tsx --test --test-force-exit test/node.test.ts test/fetch.test.ts test/browser.test.ts test/cookieJar.test.ts",
+    "coverage": "rm -rf coverage && mkdir -p coverage && tsx --test --experimental-test-coverage --test-coverage-include='src/**/*.ts' --test-coverage-exclude='test/**' --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info --test-force-exit test/node.test.ts test/fetch.test.ts test/browser.test.ts test/cookieJar.test.ts",
     "test:node": "tsx --test --test-force-exit test/node.test.ts",
     "test:fetch": "tsx --test --test-force-exit test/fetch.test.ts",
     "test:browser": "tsx --test --test-force-exit test/browser.test.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,90 +8,84 @@ importers:
 
   .:
     dependencies:
-      undici:
-        specifier: ^7.25.0
-        version: 7.25.0
+      got:
+        specifier: ^15.0.5
+        version: 15.0.5
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.4.6
-        version: 2.4.11
+        specifier: 2.4.15
+        version: 2.4.15
       '@types/node':
-        specifier: ^22.19.17
-        version: 22.19.17
+        specifier: ^22.19.19
+        version: 22.19.19
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
       tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
+        specifier: ^4.22.3
+        version: 4.22.3
       typescript:
-        specifier: ^6.0.2
-        version: 6.0.2
+        specifier: ^6.0.3
+        version: 6.0.3
 
 packages:
 
-  '@biomejs/biome@2.4.11':
-    resolution: {integrity: sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA==}
+  '@biomejs/biome@2.4.15':
+    resolution: {integrity: sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.11':
-    resolution: {integrity: sha512-wOt+ed+L2dgZanWyL6i29qlXMc088N11optzpo10peayObBaAshbTcxKUchzEMp9QSY8rh5h6VfAFE3WTS1rqg==}
+  '@biomejs/cli-darwin-arm64@2.4.15':
+    resolution: {integrity: sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.11':
-    resolution: {integrity: sha512-gZ6zR8XmZlExfi/Pz/PffmdpWOQ8Qhy7oBztgkR8/ylSRyLwfRPSadmiVCV8WQ8PoJ2MWUy2fgID9zmtgUUJmw==}
+  '@biomejs/cli-darwin-x64@2.4.15':
+    resolution: {integrity: sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.11':
-    resolution: {integrity: sha512-+Sbo1OAmlegtdwqFE8iOxFIWLh1B3OEgsuZfBpyyN/kWuqZ8dx9ZEes6zVnDMo+zRHF2wLynRVhoQmV7ohxl2Q==}
+  '@biomejs/cli-linux-arm64-musl@2.4.15':
+    resolution: {integrity: sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.4.11':
-    resolution: {integrity: sha512-avdJaEElXrKceK0va9FkJ4P5ci3N01TGkc6ni3P8l3BElqbOz42Wg2IyX3gbh0ZLEd4HVKEIrmuVu/AMuSeFFA==}
+  '@biomejs/cli-linux-arm64@2.4.15':
+    resolution: {integrity: sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.4.11':
-    resolution: {integrity: sha512-bexd2IklK7ZgPhrz6jXzpIL6dEAH9MlJU1xGTrypx+FICxrXUp4CqtwfiuoDKse+UlgAlWtzML3jrMqeEAHEhA==}
+  '@biomejs/cli-linux-x64-musl@2.4.15':
+    resolution: {integrity: sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.4.11':
-    resolution: {integrity: sha512-TagWV0iomp5LnEnxWFg4nQO+e52Fow349vaX0Q/PIcX6Zhk4GGBgp3qqZ8PVkpC+cuehRctMf3+6+FgQ8jCEFQ==}
+  '@biomejs/cli-linux-x64@2.4.15':
+    resolution: {integrity: sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.4.11':
-    resolution: {integrity: sha512-RJhaTnY8byzxDt4bDVb7AFPHkPcjOPK3xBip4ZRTrN3TEfyhjLRm3r3mqknqydgVTB74XG8l4jMLwEACEeihVg==}
+  '@biomejs/cli-win32-arm64@2.4.15':
+    resolution: {integrity: sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.11':
-    resolution: {integrity: sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A==}
+  '@biomejs/cli-win32-x64@2.4.15':
+    resolution: {integrity: sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
-
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
 
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
@@ -99,22 +93,10 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.28.0':
     resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.0':
@@ -123,34 +105,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.28.0':
     resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.28.0':
     resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.0':
@@ -159,22 +123,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.28.0':
     resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.0':
@@ -183,22 +135,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.28.0':
     resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.0':
@@ -207,22 +147,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.28.0':
     resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.0':
@@ -231,22 +159,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.28.0':
     resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.0':
@@ -255,22 +171,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.28.0':
     resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.0':
@@ -279,34 +183,16 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.28.0':
     resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.28.0':
     resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.0':
@@ -315,22 +201,10 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.28.0':
     resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.0':
@@ -339,23 +213,11 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@esbuild/openharmony-arm64@0.28.0':
     resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
-
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
 
   '@esbuild/sunos-x64@0.28.0':
     resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
@@ -363,22 +225,10 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
   '@esbuild/win32-arm64@0.28.0':
     resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.28.0':
@@ -387,25 +237,47 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
   '@esbuild/win32-x64@0.28.0':
     resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
-  '@types/node@22.19.17':
-    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sindresorhus/is@8.1.0':
+    resolution: {integrity: sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==}
+    engines: {node: '>=22'}
+
+  '@types/http-cache-semantics@4.2.0':
+    resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
+
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
+
+  byte-counter@0.1.0:
+    resolution: {integrity: sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==}
+    engines: {node: '>=20'}
+
+  cacheable-lookup@7.0.0:
+    resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
+    engines: {node: '>=14.16'}
+
+  cacheable-request@13.0.19:
+    resolution: {integrity: sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==}
     engines: {node: '>=18'}
-    hasBin: true
+
+  chunk-data@0.1.0:
+    resolution: {integrity: sha512-zFyPtyC0SZ6Zu79b9sOYtXZcgrsXe0RpePrzRyj52hYVFG1+Rk6rBqjjOEk+GNQwc3PIX+86teQMok970pod1g==}
+    engines: {node: '>=20'}
+
+  decompress-response@10.0.0:
+    resolution: {integrity: sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==}
+    engines: {node: '>=20'}
 
   esbuild@0.28.0:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
@@ -417,254 +289,226 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  get-tsconfig@4.13.7:
-    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
 
-  resolve-pkg-maps@1.0.0:
-    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+  got@15.0.5:
+    resolution: {integrity: sha512-PMIMaZuYUCK43+Z9JWEXea4kkX2b3301m81D5TS6QpfG4PmNyirzEdO/Oa2OHAN4GsjnPfvWCWsshKN2rq4/gQ==}
+    engines: {node: '>=22'}
 
-  tsx@4.21.0:
-    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http2-wrapper@2.2.1:
+    resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
+    engines: {node: '>=10.19.0'}
+
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
+
+  lowercase-keys@3.0.0:
+    resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  lowercase-keys@4.0.1:
+    resolution: {integrity: sha512-wI9Nui/L8VfADa/cr/7NQruaASk1k23/Uh1khQ02BCVYiiy8F4AhOGnQzJy3Fl/c44GnYSbZHv8g7EcG3kJ1Qg==}
+    engines: {node: '>=20'}
+
+  mimic-response@4.0.0:
+    resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  normalize-url@8.1.1:
+    resolution: {integrity: sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==}
+    engines: {node: '>=14.16'}
+
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
+
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
+
+  responselike@4.0.2:
+    resolution: {integrity: sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==}
+    engines: {node: '>=20'}
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
+  tsx@4.22.3:
+    resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  typescript@6.0.2:
-    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
-    engines: {node: '>=20.18.1'}
-
 snapshots:
 
-  '@biomejs/biome@2.4.11':
+  '@biomejs/biome@2.4.15':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.11
-      '@biomejs/cli-darwin-x64': 2.4.11
-      '@biomejs/cli-linux-arm64': 2.4.11
-      '@biomejs/cli-linux-arm64-musl': 2.4.11
-      '@biomejs/cli-linux-x64': 2.4.11
-      '@biomejs/cli-linux-x64-musl': 2.4.11
-      '@biomejs/cli-win32-arm64': 2.4.11
-      '@biomejs/cli-win32-x64': 2.4.11
+      '@biomejs/cli-darwin-arm64': 2.4.15
+      '@biomejs/cli-darwin-x64': 2.4.15
+      '@biomejs/cli-linux-arm64': 2.4.15
+      '@biomejs/cli-linux-arm64-musl': 2.4.15
+      '@biomejs/cli-linux-x64': 2.4.15
+      '@biomejs/cli-linux-x64-musl': 2.4.15
+      '@biomejs/cli-win32-arm64': 2.4.15
+      '@biomejs/cli-win32-x64': 2.4.15
 
-  '@biomejs/cli-darwin-arm64@2.4.11':
+  '@biomejs/cli-darwin-arm64@2.4.15':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.11':
+  '@biomejs/cli-darwin-x64@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.11':
+  '@biomejs/cli-linux-arm64-musl@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.11':
+  '@biomejs/cli-linux-arm64@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.11':
+  '@biomejs/cli-linux-x64-musl@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.11':
+  '@biomejs/cli-linux-x64@2.4.15':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.11':
+  '@biomejs/cli-win32-arm64@2.4.15':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.11':
-    optional: true
-
-  '@esbuild/aix-ppc64@0.27.7':
+  '@biomejs/cli-win32-x64@2.4.15':
     optional: true
 
   '@esbuild/aix-ppc64@0.28.0':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
-    optional: true
-
   '@esbuild/android-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/android-arm@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.28.0':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
-    optional: true
-
   '@esbuild/android-x64@0.28.0':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.28.0':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
-    optional: true
-
   '@esbuild/darwin-x64@0.28.0':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.28.0':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/freebsd-x64@0.28.0':
-    optional: true
-
-  '@esbuild/linux-arm64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.28.0':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
-    optional: true
-
   '@esbuild/linux-arm@0.28.0':
-    optional: true
-
-  '@esbuild/linux-ia32@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.28.0':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
-    optional: true
-
   '@esbuild/linux-loong64@0.28.0':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.28.0':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.7':
-    optional: true
-
   '@esbuild/linux-ppc64@0.28.0':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.28.0':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.7':
-    optional: true
-
   '@esbuild/linux-s390x@0.28.0':
-    optional: true
-
-  '@esbuild/linux-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.28.0':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    optional: true
-
   '@esbuild/netbsd-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-x64@0.28.0':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    optional: true
-
   '@esbuild/openbsd-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.28.0':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    optional: true
-
   '@esbuild/openharmony-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/sunos-x64@0.27.7':
     optional: true
 
   '@esbuild/sunos-x64@0.28.0':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.7':
-    optional: true
-
   '@esbuild/win32-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/win32-ia32@0.27.7':
     optional: true
 
   '@esbuild/win32-ia32@0.28.0':
     optional: true
 
-  '@esbuild/win32-x64@0.27.7':
-    optional: true
-
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
-  '@types/node@22.19.17':
+  '@keyv/serialize@1.1.1': {}
+
+  '@sec-ant/readable-stream@0.4.1': {}
+
+  '@sindresorhus/is@8.1.0': {}
+
+  '@types/http-cache-semantics@4.2.0': {}
+
+  '@types/node@22.19.19':
     dependencies:
       undici-types: 6.21.0
 
-  esbuild@0.27.7:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
+  byte-counter@0.1.0: {}
+
+  cacheable-lookup@7.0.0: {}
+
+  cacheable-request@13.0.19:
+    dependencies:
+      '@types/http-cache-semantics': 4.2.0
+      get-stream: 9.0.1
+      http-cache-semantics: 4.2.0
+      keyv: 5.6.0
+      mimic-response: 4.0.0
+      normalize-url: 8.1.1
+      responselike: 4.0.2
+
+  chunk-data@0.1.0: {}
+
+  decompress-response@10.0.0:
+    dependencies:
+      mimic-response: 4.0.0
 
   esbuild@0.28.0:
     optionalDependencies:
@@ -698,21 +542,69 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  get-tsconfig@4.13.7:
+  get-stream@9.0.1:
     dependencies:
-      resolve-pkg-maps: 1.0.0
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
 
-  resolve-pkg-maps@1.0.0: {}
-
-  tsx@4.21.0:
+  got@15.0.5:
     dependencies:
-      esbuild: 0.27.7
-      get-tsconfig: 4.13.7
+      '@sindresorhus/is': 8.1.0
+      byte-counter: 0.1.0
+      cacheable-lookup: 7.0.0
+      cacheable-request: 13.0.19
+      chunk-data: 0.1.0
+      decompress-response: 10.0.0
+      http2-wrapper: 2.2.1
+      keyv: 5.6.0
+      lowercase-keys: 4.0.1
+      responselike: 4.0.2
+      type-fest: 5.6.0
+      uint8array-extras: 1.5.0
+
+  http-cache-semantics@4.2.0: {}
+
+  http2-wrapper@2.2.1:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
+
+  is-stream@4.0.1: {}
+
+  keyv@5.6.0:
+    dependencies:
+      '@keyv/serialize': 1.1.1
+
+  lowercase-keys@3.0.0: {}
+
+  lowercase-keys@4.0.1: {}
+
+  mimic-response@4.0.0: {}
+
+  normalize-url@8.1.1: {}
+
+  quick-lru@5.1.1: {}
+
+  resolve-alpn@1.2.1: {}
+
+  responselike@4.0.2:
+    dependencies:
+      lowercase-keys: 3.0.0
+
+  tagged-tag@1.0.0: {}
+
+  tsx@4.22.3:
+    dependencies:
+      esbuild: 0.28.0
     optionalDependencies:
       fsevents: 2.3.3
 
-  typescript@6.0.2: {}
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
+  typescript@6.0.3: {}
+
+  uint8array-extras@1.5.0: {}
 
   undici-types@6.21.0: {}
-
-  undici@7.25.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,16 +16,16 @@ importers:
         specifier: 2.4.15
         version: 2.4.15
       '@types/node':
-        specifier: ^22.19.19
+        specifier: 22.19.19
         version: 22.19.19
       esbuild:
-        specifier: ^0.28.0
+        specifier: 0.28.0
         version: 0.28.0
       tsx:
-        specifier: ^4.22.3
-        version: 4.22.3
+        specifier: 4.22.2
+        version: 4.22.2
       typescript:
-        specifier: ^6.0.3
+        specifier: 6.0.3
         version: 6.0.3
 
 packages:
@@ -342,8 +342,8 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tsx@4.22.3:
-    resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
+  tsx@4.22.2:
+    resolution: {integrity: sha512-6w9FwtT8WQqRAyTNR+Z+86kghRqpmOLjXUrBlBT6T+CQGDuIMm0VmAqaFUFBIeKDTGobE6/YSigZYLeomzBaRg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -593,7 +593,7 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tsx@4.22.3:
+  tsx@4.22.2:
     dependencies:
       esbuild: 0.28.0
     optionalDependencies:

--- a/src/cookieJar.ts
+++ b/src/cookieJar.ts
@@ -81,8 +81,7 @@ export class CookieJar {
     const now = new Date();
     const isSecure = url.protocol === "https:";
     const live = cookies.filter((cookie) => {
-      if (cookie.expires && cookie.expires <= now) return false;
-      return true;
+      return !(cookie.expires && cookie.expires <= now);
     });
 
     // Write back to evict expired cookies from storage

--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -1,36 +1,38 @@
 /**
- * Node.js HTTP client backed by {@link https://undici.nodejs.org | undici}.
+ * Node.js HTTP client backed by {@link https://github.com/sindresorhus/got | got}.
  *
  * @remarks
  * This entry point is selected when the package is imported from Node.js
- * (via the `"node"` export condition). It uses undici's `Agent` with
- * configurable HTTP/2 support (`allowH2`). Agents are cached per origin
- * so connections are reused across requests to the same host.
+ * (via the `"node"` export condition). It uses {@link got} for transport,
+ * which provides:
+ *
+ *  - HTTP/2 negotiation via `http2-wrapper` (`http2: true`).
+ *  - Transparent decompression of `br`, `gzip`, and `deflate` response bodies
+ *    on both HTTP/1.1 and HTTP/2 (`decompress: true`, the default).
+ *  - Built-in connection pooling — we don't manage our own dispatcher cache.
+ *
+ * Historical note: v3 of this package replaced `got` with `undici`, but the
+ * `fetch + custom dispatcher` combination silently dropped response headers
+ * (including `set-cookie`) and failed to decompress responses on H2 (and
+ * via the fetch wrapper on H1 too). v4 returns to `got` because its body
+ * pipeline handles decompression independent of the transport, which is the
+ * only shape that works reliably with the Aptos fullnode (brotli) and
+ * indexer (gzip) endpoints.
  *
  * @module index.node
  */
-import { Agent } from "undici";
+import { type IncomingMessage, STATUS_CODES } from "node:http";
+import got, { HTTPError, RequestError } from "got";
 import { CookieJar } from "./cookieJar.js";
-import {
-  applyCookiesToHeaders,
-  applyJsonContentType,
-  buildUrl,
-  headersToRecord,
-  parseJsonSafely,
-  serializeBody,
-  storeResponseCookies,
-} from "./shared.js";
+import { buildUrl, serializeBody } from "./shared.js";
 import type { AptosClientRequest, AptosClientResponse, CookieJarLike } from "./types.js";
 
 export type { Cookie } from "./cookieJar.js";
 export { CookieJar } from "./cookieJar.js";
 export type { AptosClientRequest, AptosClientResponse, CookieJarLike } from "./types.js";
 
+const textDecoder = new TextDecoder("utf-8");
 const defaultCookieJar = new CookieJar();
-
-/** One dispatcher per origin + HTTP/2 mode for connection reuse. */
-const dispatcherCache = new Map<string, Agent>();
-const MAX_DISPATCHERS = 50;
 
 /**
  * Send a JSON request to an Aptos API endpoint.
@@ -98,92 +100,173 @@ async function doRequest<Res>(
   }
 
   const requestUrl = buildUrl(url, params);
-  const requestHeaders = buildHeaders(requestUrl, headers, jar);
-  const dispatcher = getDispatcher(requestUrl.origin, http2);
+  const requestHeaders = buildHeaders(requestUrl, headers, body, jar);
+  // `serializeBody` returns string | Uint8Array | undefined; got accepts both as `body`.
+  const serialized = serializeBody(body) as string | Uint8Array | undefined;
 
-  const init: RequestInit & { dispatcher?: Agent } = {
-    method,
-    headers: requestHeaders,
-    dispatcher,
-  };
-
-  const serialized = serializeBody(body);
-  if (serialized !== undefined) {
-    init.body = serialized;
-    applyJsonContentType(body, requestHeaders);
+  let response: {
+    body: Uint8Array<ArrayBuffer>;
+    statusCode: number;
+  } & IncomingMessage;
+  try {
+    response = await got(requestUrl, {
+      method,
+      headers: requestHeaders,
+      body: serialized,
+      http2,
+      // Don't throw on 4xx/5xx — callers (e.g., the TS SDK) inspect the
+      // status code and handle errors themselves. Matches v2 behavior.
+      throwHttpErrors: false,
+      // Disable retries; SDK callers manage their own retry policy.
+      retry: { limit: 0 },
+      // Body comes back as a Uint8Array; we decode JSON / hand back ArrayBuffer
+      // ourselves so the empty-body and BCS cases stay consistent.
+      responseType: "buffer",
+      // `decompress: true` is the default — listed explicitly to make the
+      // intent (transparent br/gzip/deflate decoding) visible.
+      decompress: true,
+      // got's H2 path (via http2-wrapper) sets its own TLS context and does
+      // NOT inherit `NODE_TLS_REJECT_UNAUTHORIZED` from the env. Pass it
+      // through explicitly, so the documented Node env var works as expected.
+      https: {
+        rejectUnauthorized: process.env.NODE_TLS_REJECT_UNAUTHORIZED !== "0",
+      },
+    });
+  } catch (err) {
+    // got throws for transport-level failures (DNS, ECONNREFUSED, parse errors).
+    // HTTP 4xx/5xx do NOT throw thanks to throwHttpErrors: false. We preserve
+    // a v2-compatible shape: if there's an attached response, surface it as a
+    // normal AptosClientResponse so callers can read .status.
+    if ((err instanceof HTTPError || err instanceof RequestError) && err.response) {
+      response = err.response;
+    } else {
+      throw err;
+    }
   }
 
-  const res = await fetch(requestUrl, init);
+  storeResponseCookies(requestUrl, response.headers, jar);
 
-  storeResponseCookies(requestUrl, res.headers, jar);
+  // got's `responseType: "buffer"` returns a Uint8Array (not a Node Buffer)
+  // in v15+.
+  const raw = response.body;
 
-  const data = mode === "json" ? await parseJsonSafely(res) : await res.arrayBuffer();
+  // TODO: at some point provide better type guarantees, since there is some legacy behavior in here
+  // biome-ignore lint/suspicious/noExplicitAny: legacy behavior, union of multiple body shapes
+  let data: any;
+  if (mode === "arrayBuffer") {
+    // Slice out a fresh ArrayBuffer that matches the body length exactly.
+    data = response.body.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength);
+  } else if (response.statusCode === 204 || response.statusCode === 205 || response.body.byteLength === 0) {
+    data = null;
+  } else {
+    const text = textDecoder.decode(response.body);
+    try {
+      data = JSON.parse(text);
+    } catch {
+      // Backward compat: return raw text so callers can inspect non-JSON bodies.
+      data = text;
+    }
+  }
 
   return {
-    status: res.status,
-    statusText: res.statusText,
+    status: response.statusCode,
+    statusText: response.statusMessage ?? STATUS_CODES[response.statusCode] ?? "",
     data,
-    config: { ...init, headers: headersToRecord(requestHeaders) },
+    config: {
+      method,
+      headers: requestHeaders,
+      body: serialized,
+    },
     request: {
       url: requestUrl.toString(),
       method,
     },
-    response: res,
-    headers: headersToRecord(res.headers),
+    response,
+    headers: normalizeHeaders(response.headers),
   };
 }
 
 /**
- * Return a cached undici `Agent` for the given origin, creating one if needed.
+ * Build the outgoing header record: caller-supplied headers, jar cookies,
+ * and a default JSON `content-type` for non-binary bodies.
  *
- * @param origin - URL origin (scheme + host + port).
- * @param http2 - Whether to enable HTTP/2 via ALPN (`allowH2`).
+ * @remarks
+ * Unlike the v3 (undici) implementation, we do NOT need to manage
+ * `accept-encoding` here — `got` advertises the encodings it can decode
+ * and decompresses the response body transparently.
+ *
  * @internal
  */
-function getDispatcher(origin: string, http2: boolean): Agent {
-  const key = `${origin}|h2=${http2}`;
-  const cached = dispatcherCache.get(key);
-  if (cached) {
-    // Move to end of Map (most-recently-used)
-    dispatcherCache.delete(key);
-    dispatcherCache.set(key, cached);
-    return cached;
-  }
-
-  // Evict oldest entry if cache is full
-  if (dispatcherCache.size >= MAX_DISPATCHERS) {
-    // biome-ignore lint/style/noNonNullAssertion: cache size check guarantees entry exists
-    const oldest = dispatcherCache.keys().next().value!;
-    // biome-ignore lint/style/noNonNullAssertion: oldest key was just retrieved from cache
-    dispatcherCache
-      .get(oldest)!
-      .destroy()
-      .catch(() => {});
-    dispatcherCache.delete(oldest);
-  }
-
-  const agent = new Agent({
-    allowH2: http2,
-  });
-
-  dispatcherCache.set(key, agent);
-  return agent;
-}
-
-/**
- * Merge caller-supplied headers with cookies from the jar.
- * @internal
- */
-function buildHeaders(url: URL, headers: AptosClientRequest["headers"] | undefined, jar: CookieJarLike): Headers {
-  const result = new Headers();
+function buildHeaders(
+  url: URL,
+  headers: AptosClientRequest["headers"] | undefined,
+  body: unknown,
+  jar: CookieJarLike,
+): Record<string, string> {
+  const result: Record<string, string> = {};
 
   for (const [key, value] of Object.entries(headers ?? {})) {
     if (value !== undefined) {
-      result.set(key, String(value));
+      result[key.toLowerCase()] = String(value);
     }
   }
 
-  applyCookiesToHeaders(result, url, jar);
+  if (body != null && !(body instanceof Uint8Array) && !("content-type" in result)) {
+    result["content-type"] = "application/json";
+  }
 
+  applyJarCookies(result, url, jar);
+
+  return result;
+}
+
+/**
+ * Merge jar cookies into the outgoing `cookie` header.
+ * @internal
+ */
+function applyJarCookies(headers: Record<string, string>, url: URL, jar: CookieJarLike): void {
+  const cookies = jar.getCookies(url);
+  if (cookies.length === 0) return;
+  const jarCookies = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+  const existing = headers.cookie;
+  headers.cookie = existing ? `${existing}; ${jarCookies}` : jarCookies;
+}
+
+/**
+ * Extract `set-cookie` headers from the response and store them in the jar.
+ *
+ * `got` returns `set-cookie` as `string[]` (one entry per cookie) on
+ * `response.headers["set-cookie"]`. Other headers are plain strings.
+ *
+ * @internal
+ */
+function storeResponseCookies(
+  url: URL,
+  headers: Record<string, string | string[] | undefined>,
+  jar: CookieJarLike,
+): void {
+  const setCookie = headers["set-cookie"];
+  if (!setCookie) return;
+  const cookies = Array.isArray(setCookie) ? setCookie : [setCookie];
+  for (const cookie of cookies) {
+    jar.setCookie(url, cookie);
+  }
+}
+
+/**
+ * Normalize got's header record to the v2-compatible response-headers shape.
+ *
+ * got already gives us lowercased plain-object headers; we strip undefined
+ * entries so downstream callers see only present headers.
+ *
+ * @internal
+ */
+function normalizeHeaders(headers: Record<string, string | string[] | undefined>): Record<string, string | string[]> {
+  const result: Record<string, string | string[]> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value !== undefined) {
+      result[key] = value;
+    }
+  }
   return result;
 }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -48,7 +48,7 @@ export function serializeBody(body: unknown): BodyInit | undefined {
 
 /**
  * Set the `content-type` header to `application/json` when the body is
- * a non-binary, non-null value and no content-type has been set already.
+ * a non-binary, non-null value and no content-type has been set.
  * @internal
  */
 export function applyJsonContentType(body: unknown, headers: Headers): void {
@@ -62,7 +62,7 @@ export function applyJsonContentType(body: unknown, headers: Headers): void {
  *
  * Returning raw text (instead of throwing) preserves backward compatibility
  * with v2, where `got` returned error responses as normal `AptosClientResponse`
- * objects. This lets the caller (e.g. the TS SDK) inspect the status code and
+ * objects. This lets the caller (e.g., the TS SDK) inspect the status code and
  * handle the error however it chooses.
  *
  * @internal
@@ -115,7 +115,7 @@ export function storeResponseCookies(url: URL, headers: Headers, jar: CookieJarL
  *
  * This preserves backward compatibility with aptos-client v2, which
  * returned Node's `IncomingHttpHeaders` (a plain object) from the `got`
- * library. Consumers (e.g. the TS SDK) access headers via bracket
+ * library. Consumers (e.g., the TS SDK) access headers via bracket
  * notation (`response.headers["x-aptos-cursor"]`), which only works on
  * plain objects — not on `Headers` instances.
  *

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export type AptosClientResponse<Res> = {
   statusText: string;
   /** Parsed response body. */
   data: Res;
-  /** The `RequestInit` (or undici equivalent) that was sent. */
+  /** The request options that were sent (shape varies per entry point). */
   // biome-ignore lint/suspicious/noExplicitAny: cross-platform response type; varies per entry point
   config?: any;
   /** Metadata about the outgoing request (Node entry point only). */
@@ -74,10 +74,11 @@ export type AptosClientRequest = {
    * @defaultValue `true`
    *
    * @remarks
-   * Only effective in the **Node** entry point, where it maps to
-   * undici's `Agent({ allowH2 })`. In the **fetch**, **browser**, and
-   * **React Native** entry points the underlying runtime negotiates
-   * HTTP/2 automatically via ALPN — this option is ignored.
+   * Only effective in the **Node** entry point, where it maps to got's
+   * `http2` option (which uses `http2-wrapper` under the hood to negotiate
+   * H2 via ALPN). In the **fetch**, **browser**, and **React Native** entry
+   * points the underlying runtime negotiates HTTP/2 automatically — this
+   * option is ignored there.
    */
   http2?: boolean;
   /**

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -137,4 +137,47 @@ describe("browser client", () => {
       assert.deepEqual(res.data, { hello: "compressed", encoding }, `data for ${encoding}`);
     }
   });
+
+  it("throws on unsupported HTTP methods", async () => {
+    await assert.rejects(jsonRequest({ url: `${h1.url}/json`, method: "PUT" as any }), /Unsupported method: PUT/);
+  });
+
+  it("warns at most once when the http2 option is set (no-op in browser entry)", async () => {
+    const original = console.warn;
+    const warnings: unknown[][] = [];
+    console.warn = (...args: unknown[]) => warnings.push(args);
+    try {
+      // Fire two consecutive requests with `http2`. The module-level
+      // `http2Warned` flag must keep the count at most one across both.
+      const res1 = await jsonRequest({ url: `${h1.url}/json`, method: "GET", http2: true });
+      const res2 = await jsonRequest({ url: `${h1.url}/json`, method: "GET", http2: false });
+      assert.equal(res1.status, 200);
+      assert.equal(res2.status, 200);
+      const http2Warnings = warnings.filter((w) => String(w[0]).includes("http2"));
+      assert.ok(http2Warnings.length <= 1, `expected at most 1 http2 warning, got ${http2Warnings.length}`);
+    } finally {
+      console.warn = original;
+    }
+  });
+
+  it("WITH_CREDENTIALS=false sends `credentials: omit`", async () => {
+    // We can't inspect fetch's credentials option from the response, but
+    // exercising the branch ensures the build doesn't break and the code
+    // path is covered.
+    const res = await jsonRequest({
+      url: `${h1.url}/json`,
+      method: "GET",
+      overrides: { WITH_CREDENTIALS: false },
+    });
+    assert.equal(res.status, 200);
+  });
+
+  it("undefined header values are skipped", async () => {
+    const res = await jsonRequest({
+      url: `${h1.url}/json`,
+      method: "GET",
+      headers: { "x-defined": "yes", "x-undefined": undefined },
+    });
+    assert.equal(res.status, 200);
+  });
 });

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -1,8 +1,12 @@
 /**
  * Tests for the browser client (fetch-based, no cookie jar).
- * HTTP/2: In real browsers, HTTP/2 is negotiated automatically by the browser engine.
- * When tested under Node, HTTP/2 is NOT available (same undici limitation as fetch client).
- * The browser client has no cookie jar — cookies are managed by the browser itself.
+ *
+ * In real browsers, HTTP/2 is negotiated by the browser engine and bodies are
+ * decompressed transparently. When tested under Node we exercise the same code
+ * paths through Node's fetch; whatever Node's fetch negotiates is what we get
+ * (Node 24+ undici now supports H2 via ALPN).
+ *
+ * The browser client has no cookie jar — cookies are managed by the browser.
  */
 
 import assert from "node:assert/strict";
@@ -108,16 +112,29 @@ describe("browser client", () => {
     );
   });
 
-  it("HTTP/2: falls back to HTTP/1.1 under Node (browser would negotiate h2 natively)", async () => {
-    const res = await jsonRequest({
-      url: `${h2.url}/json`,
-      method: "GET",
-    });
+  it("HTTP/1.1: GET against an h1-only origin reports 1.1", async () => {
+    const res = await jsonRequest({ url: `${h1.url}/json`, method: "GET" });
     assert.equal(res.status, 200);
-    assert.equal(
-      res.headers?.["x-http-version"],
-      "1.1",
-      "Under Node, browser client falls back to 1.1. In a real browser, h2 is negotiated by the engine.",
-    );
+    assert.equal(res.headers?.["x-http-version"], "1.1");
+  });
+
+  it("HTTP/2: negotiates h2 via ALPN when the runtime supports it", async () => {
+    const res = await jsonRequest({ url: `${h2.url}/json`, method: "GET" });
+    assert.equal(res.status, 200);
+    const version = res.headers?.["x-http-version"];
+    assert.ok(version === "1.1" || version === "2.0", `unexpected protocol: ${version}`);
+    console.log(`  browser client negotiated: HTTP/${version}`);
+  });
+
+  it("decompresses brotli/gzip/deflate transparently", async () => {
+    for (const encoding of ["br", "gzip", "deflate"] as const) {
+      const res = await jsonRequest({
+        url: `${h1.url}/compressed`,
+        method: "GET",
+        params: { encoding },
+      });
+      assert.equal(res.status, 200, `status for ${encoding}`);
+      assert.deepEqual(res.data, { hello: "compressed", encoding }, `data for ${encoding}`);
+    }
   });
 });

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -8,8 +8,9 @@
  *
  * Prerequisites: the package must be built (`pnpm build`) before running.
  */
+import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, statSync, symlinkSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
@@ -43,41 +44,43 @@ describe("Build compatibility", () => {
   describe("tsc", () => {
     for (const resolution of ["bundler", "nodenext"] as const) {
       it(`moduleResolution: ${resolution}`, () => {
-        execFileSync(TSC, ["--project", join(FIXTURE_DIR, `tsconfig.${resolution}.json`)], {
+        // tsc exits non-zero on type errors; execFileSync throws on that.
+        const stdout = execFileSync(TSC, ["--project", join(FIXTURE_DIR, `tsconfig.${resolution}.json`)], {
           cwd: FIXTURE_DIR,
           stdio: "pipe",
           timeout: 30_000,
         });
+        // tsc on success produces empty stdout; any output here indicates a warning
+        // that should be surfaced rather than silently swallowed.
+        assert.equal(stdout.toString().trim(), "", `tsc produced unexpected output: ${stdout}`);
+        // Verify the package's declaration files were actually consumed.
+        const distTypes = join(ROOT, "dist", "index.node.d.ts");
+        assert.ok(existsSync(distTypes), `expected ${distTypes} to exist (run pnpm build first)`);
       });
     }
   });
 
   describe("esbuild", () => {
+    const outFile = join(FIXTURE_DIR, "out.js");
+
     it("platform: node", () => {
       execFileSync(
         ESBUILD,
-        [
-          join(FIXTURE_DIR, "consumer.ts"),
-          "--bundle",
-          "--platform=node",
-          "--external:got",
-          `--outfile=${join(FIXTURE_DIR, "out.js")}`,
-        ],
+        [join(FIXTURE_DIR, "consumer.ts"), "--bundle", "--platform=node", "--external:got", `--outfile=${outFile}`],
         { cwd: ROOT, stdio: "pipe", timeout: 30_000 },
       );
+      assert.ok(existsSync(outFile), "esbuild should have produced out.js");
+      assert.ok(statSync(outFile).size > 0, "out.js should not be empty");
     });
 
     it("platform: browser", () => {
       execFileSync(
         ESBUILD,
-        [
-          join(FIXTURE_DIR, "consumer-browser.ts"),
-          "--bundle",
-          "--platform=browser",
-          `--outfile=${join(FIXTURE_DIR, "out.js")}`,
-        ],
+        [join(FIXTURE_DIR, "consumer-browser.ts"), "--bundle", "--platform=browser", `--outfile=${outFile}`],
         { cwd: ROOT, stdio: "pipe", timeout: 30_000 },
       );
+      assert.ok(existsSync(outFile), "esbuild should have produced out.js");
+      assert.ok(statSync(outFile).size > 0, "out.js should not be empty");
     });
   });
 });

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -60,7 +60,7 @@ describe("Build compatibility", () => {
           join(FIXTURE_DIR, "consumer.ts"),
           "--bundle",
           "--platform=node",
-          "--external:undici",
+          "--external:got",
           `--outfile=${join(FIXTURE_DIR, "out.js")}`,
         ],
         { cwd: ROOT, stdio: "pipe", timeout: 30_000 },

--- a/test/bun.integration.ts
+++ b/test/bun.integration.ts
@@ -93,8 +93,27 @@ describe("bun — HTTP/2", () => {
     expect(res.status).toBe(200);
     const version = res.headers["x-http-version"];
     console.log(`  Bun negotiated HTTP version: ${version}`);
-    // Bun 1.x fetch does NOT negotiate HTTP/2 — it falls back to 1.1.
-    // This is a known Bun limitation. Track: https://github.com/oven-sh/bun/issues/887
-    expect(version).toBe("1.1");
+    // Bun added HTTP/2 client support after the original release of this
+    // suite. Accept either "2.0" (modern Bun, expected) or "1.1" (older
+    // Bun) so the test stays accurate across versions.
+    expect(["1.1", "2.0"]).toContain(version);
+  });
+
+  it("HTTP/1.1: GET against an h1-only origin reports 1.1", async () => {
+    const res = await jsonRequest({ url: `${h1Url}/json`, method: "GET" });
+    expect(res.status).toBe(200);
+    expect(res.headers["x-http-version"]).toBe("1.1");
+  });
+
+  it("decompresses brotli/gzip/deflate transparently", async () => {
+    for (const encoding of ["br", "gzip", "deflate"] as const) {
+      const res = await jsonRequest({
+        url: `${h1Url}/compressed`,
+        method: "GET",
+        params: { encoding },
+      });
+      expect(res.status).toBe(200);
+      expect(res.data).toEqual({ hello: "compressed", encoding });
+    }
   });
 });

--- a/test/deno.integration.ts
+++ b/test/deno.integration.ts
@@ -163,7 +163,16 @@ Deno.test({
 Deno.test({
   name: "deno integration — teardown servers",
   fn: () => {
-    stopServers();
+    // No-throw assertion: stopServers swallows already-exited errors, so we
+    // verify the call returns cleanly. The presence of the test in the suite
+    // guarantees cleanup runs even when earlier tests fail.
+    let threw = false;
+    try {
+      stopServers();
+    } catch {
+      threw = true;
+    }
+    assert(!threw, "stopServers should not throw");
   },
   sanitizeOps: false,
   sanitizeResources: false,

--- a/test/deno.integration.ts
+++ b/test/deno.integration.ts
@@ -133,6 +133,34 @@ Deno.test({
 });
 
 Deno.test({
+  name: "deno — HTTP/1.1 against h1-only origin",
+  fn: async () => {
+    const res = await jsonRequest({ url: `${h1Url}/json`, method: "GET" });
+    assertEquals(res.status, 200);
+    assertEquals(res.headers?.["x-http-version"], "1.1");
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "deno — decompresses brotli/gzip/deflate transparently",
+  fn: async () => {
+    for (const encoding of ["br", "gzip", "deflate"] as const) {
+      const res = await jsonRequest({
+        url: `${h1Url}/compressed`,
+        method: "GET",
+        params: { encoding },
+      });
+      assertEquals(res.status, 200);
+      assertEquals(res.data, { hello: "compressed", encoding });
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
   name: "deno integration — teardown servers",
   fn: () => {
     stopServers();

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1,7 +1,17 @@
 /**
- * Tests for the fetch-based client (designed for Deno/Bun).
- * When run under Node, HTTP/2 is NOT available (Node's fetch/undici doesn't support h2).
- * When run under Deno or Bun, HTTP/2 is negotiated automatically via ALPN.
+ * Tests for the fetch-based client (used by Deno/Bun/edge runtimes; also runs
+ * under Node for unit coverage).
+ *
+ * HTTP/2: the runtime's native fetch decides. Today this means:
+ *  - Node 24+ (undici 7+): negotiates HTTP/2 via ALPN.
+ *  - Deno: HTTP/2 via ALPN (covered by `deno.integration.ts`).
+ *  - Bun (recent): HTTP/2 via ALPN (covered by `bun.integration.ts`).
+ *
+ * The H2 assertion below reports the negotiated version rather than pinning a
+ * specific one so the test remains accurate as runtimes evolve.
+ *
+ * Decompression: the runtime's fetch transparently decodes `br`, `gzip`, and
+ * `deflate` bodies — verified by `/compressed` returning parsed JSON.
  */
 
 import assert from "node:assert/strict";
@@ -106,17 +116,31 @@ describe("fetch client", () => {
     );
   });
 
-  it("HTTP/2: Node's fetch (undici) falls back to HTTP/1.1", async () => {
-    const res = await jsonRequest({
-      url: `${h2.url}/json`,
-      method: "GET",
-    });
+  it("HTTP/1.1: GET against an h1-only origin reports 1.1", async () => {
+    const res = await jsonRequest({ url: `${h1.url}/json`, method: "GET" });
     assert.equal(res.status, 200);
-    // Node's undici-based fetch cannot negotiate HTTP/2 — always falls back to 1.1
-    assert.equal(
-      res.headers?.["x-http-version"],
-      "1.1",
-      "Under Node, fetch does NOT support HTTP/2. Deno and Bun negotiate h2 automatically.",
-    );
+    assert.equal(res.headers?.["x-http-version"], "1.1");
+  });
+
+  it("HTTP/2: negotiates h2 via ALPN against an h2 origin (runtime-dependent)", async () => {
+    const res = await jsonRequest({ url: `${h2.url}/json`, method: "GET" });
+    assert.equal(res.status, 200);
+    const version = res.headers?.["x-http-version"];
+    // Whichever the runtime chose, it must be a valid HTTP version. Under
+    // Node 24+ undici fetch this is "2.0"; older Nodes fell back to "1.1".
+    assert.ok(version === "1.1" || version === "2.0", `unexpected protocol: ${version}`);
+    console.log(`  fetch client negotiated: HTTP/${version}`);
+  });
+
+  it("decompresses brotli/gzip/deflate transparently", async () => {
+    for (const encoding of ["br", "gzip", "deflate"] as const) {
+      const res = await jsonRequest({
+        url: `${h1.url}/compressed`,
+        method: "GET",
+        params: { encoding },
+      });
+      assert.equal(res.status, 200, `status for ${encoding}`);
+      assert.deepEqual(res.data, { hello: "compressed", encoding }, `data for ${encoding}`);
+    }
   });
 });

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -143,4 +143,36 @@ describe("fetch client", () => {
       assert.deepEqual(res.data, { hello: "compressed", encoding }, `data for ${encoding}`);
     }
   });
+
+  it("BCS request handles compressed responses", async () => {
+    const res = await bcsRequest({
+      url: `${h1.url}/compressed`,
+      method: "GET",
+      params: { encoding: "br" },
+    });
+    assert.equal(res.status, 200);
+    const text = new TextDecoder().decode(new Uint8Array(res.data));
+    assert.equal(text, JSON.stringify({ hello: "compressed", encoding: "br" }));
+  });
+
+  it("throws on unsupported HTTP methods", async () => {
+    await assert.rejects(jsonRequest({ url: `${h1.url}/json`, method: "DELETE" as any }), /Unsupported method: DELETE/);
+  });
+
+  it("undefined header values are skipped", async () => {
+    const res = await jsonRequest({
+      url: `${h1.url}/json`,
+      method: "GET",
+      headers: { "x-defined": "yes", "x-undefined": undefined },
+    });
+    assert.equal(res.status, 200);
+  });
+
+  it("ignores http2 option (runtime handles negotiation)", async () => {
+    // Setting http2 explicitly should be a no-op in this entry — exercises
+    // the branch that records `http2` in requestConfig without altering the
+    // request semantics.
+    const res = await jsonRequest({ url: `${h1.url}/json`, method: "GET", http2: true });
+    assert.equal(res.status, 200);
+  });
 });

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -1,6 +1,7 @@
 /**
- * Tests for the Node.js client (undici-based).
- * HTTP/2: SUPPORTED — undici Agent with allowH2: true negotiates h2 via ALPN.
+ * Tests for the Node.js client (got-based).
+ * HTTP/2: SUPPORTED — got negotiates h2 via ALPN when `http2: true`.
+ * Decompression: SUPPORTED — got transparently decodes br / gzip / deflate.
  */
 
 import assert from "node:assert/strict";
@@ -11,7 +12,7 @@ import { startH1Server, startH2Server, type TestServer } from "./server.js";
 // Allow self-signed certs for h2 tests
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
-describe("node client (undici)", () => {
+describe("node client (got)", () => {
   let h1: TestServer;
   let h2: TestServer;
 
@@ -65,7 +66,6 @@ describe("node client (undici)", () => {
   it("BCS request returns binary data", async () => {
     const res = await bcsRequest({ url: `${h1.url}/bcs`, method: "GET" });
     assert.equal(res.status, 200);
-    // undici returns ArrayBuffer from res.arrayBuffer()
     assert.ok(res.data instanceof ArrayBuffer, "bcsRequest should return ArrayBuffer");
     const bytes = new Uint8Array(res.data as ArrayBuffer);
     assert.deepEqual([...bytes], [0xde, 0xad, 0xbe, 0xef]);
@@ -113,7 +113,7 @@ describe("node client (undici)", () => {
       http2: true,
     });
     assert.equal(res.status, 200);
-    assert.equal(res.headers?.["x-http-version"], "2.0", "undici with allowH2 should negotiate HTTP/2 via ALPN");
+    assert.equal(res.headers?.["x-http-version"], "2.0", "got with http2: true should negotiate HTTP/2 via ALPN");
   });
 
   it("HTTP/2: falls back to HTTP/1.1 when http2: false", async () => {
@@ -124,6 +124,77 @@ describe("node client (undici)", () => {
     });
     assert.equal(res.status, 200);
     assert.equal(res.headers?.["x-http-version"], "1.1");
+  });
+
+  it("HTTP/1.1: GET against an h1-only origin reports 1.1", async () => {
+    const res = await jsonRequest({ url: `${h1.url}/json`, method: "GET" });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers?.["x-http-version"], "1.1");
+  });
+
+  // Bug-2 regression: in v3.x (undici-based), fullnode brotli responses
+  // surfaced as binary-prefixed strings that JSON.parse couldn't handle —
+  // the `fetch + custom dispatcher` combination silently bypassed undici's
+  // decompression on both H1 and H2. Returning to got (which decompresses
+  // in its own body pipeline, independent of the transport) restores the
+  // v2-era behavior where compressed bodies just work.
+  it("decompresses brotli on h2 and yields parsed JSON", async () => {
+    const res = await jsonRequest({
+      url: `${h2.url}/compressed`,
+      method: "GET",
+      params: { encoding: "br" },
+      http2: true,
+    });
+    assert.equal(res.status, 200);
+    assert.equal(typeof res.data, "object", `expected parsed object, got ${typeof res.data}`);
+    assert.deepEqual(res.data, { hello: "compressed", encoding: "br" });
+    // The server saw a compression-allowing accept-encoding, so the wire
+    // body was compressed, and our pipeline decoded it.
+    assert.ok(
+      String(res.headers?.["x-accept-encoding-seen"] ?? "").includes("br"),
+      "client should advertise brotli support by default",
+    );
+    // The response should not still claim to be compressed after decoding.
+    assert.equal(res.headers?.["content-encoding"], undefined);
+  });
+
+  it("decompresses br / gzip / deflate on HTTP/1.1", async () => {
+    for (const encoding of ["br", "gzip", "deflate"] as const) {
+      const res = await jsonRequest({
+        url: `${h1.url}/compressed`,
+        method: "GET",
+        params: { encoding },
+      });
+      assert.equal(res.status, 200, `status for ${encoding}`);
+      assert.deepEqual(res.data, { hello: "compressed", encoding }, `data for ${encoding}`);
+      assert.equal(res.headers?.["content-encoding"], undefined, `content-encoding stripped for ${encoding}`);
+    }
+  });
+
+  it("BCS path also decompresses the body before returning bytes", async () => {
+    const res = await bcsRequest({
+      url: `${h1.url}/compressed`,
+      method: "GET",
+      params: { encoding: "br" },
+    });
+    assert.equal(res.status, 200);
+    // Decoded bytes should be the original JSON, not the brotli stream.
+    const text = new TextDecoder().decode(new Uint8Array(res.data as ArrayBuffer));
+    assert.equal(text, JSON.stringify({ hello: "compressed", encoding: "br" }));
+  });
+
+  it("caller-provided accept-encoding overrides the default", async () => {
+    const res = await jsonRequest({
+      url: `${h1.url}/compressed`,
+      method: "GET",
+      params: { encoding: "gzip" },
+      headers: { "accept-encoding": "identity" },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers?.["x-accept-encoding-seen"], "identity");
+    // Server should have skipped compression entirely.
+    assert.equal(res.headers?.["content-encoding"], undefined);
+    assert.deepEqual(res.data, { hello: "compressed", encoding: "gzip" });
   });
 
   it("HTTP/2: BCS over h2", async () => {

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -208,4 +208,39 @@ describe("node client (got)", () => {
     const bytes = new Uint8Array(res.data as ArrayBuffer);
     assert.deepEqual([...bytes], [0xde, 0xad, 0xbe, 0xef]);
   });
+
+  it("throws on unsupported HTTP methods", async () => {
+    await assert.rejects(jsonRequest({ url: `${h1.url}/json`, method: "PATCH" as any }), /Unsupported method: PATCH/);
+  });
+
+  it("undefined header values are skipped", async () => {
+    const res = await jsonRequest({
+      url: `${h1.url}/json`,
+      method: "GET",
+      headers: { "x-defined": "yes", "x-undefined": undefined },
+    });
+    assert.equal(res.status, 200);
+  });
+
+  it("per-request cookie jar isolates state", async () => {
+    const { CookieJar } = await import("../src/cookieJar.js");
+    const jar = new CookieJar();
+    await jsonRequest({ url: `${h1.url}/set-cookie`, method: "GET", cookieJar: jar });
+    const res = await jsonRequest({
+      url: `${h1.url}/get-cookie`,
+      method: "GET",
+      cookieJar: jar,
+    });
+    assert.equal(res.status, 200);
+    assert.ok((res.data as any).cookie.includes("test=value123"), "per-request jar should round-trip its own cookies");
+
+    // A different jar should NOT receive the same cookie.
+    const otherJar = new CookieJar();
+    const res2 = await jsonRequest({
+      url: `${h1.url}/get-cookie`,
+      method: "GET",
+      cookieJar: otherJar,
+    });
+    assert.equal((res2.data as any).cookie, "");
+  });
 });

--- a/test/server.ts
+++ b/test/server.ts
@@ -122,21 +122,27 @@ function handler(req: Req, res: Res) {
         res.end(payload);
         return;
       }
+      // Only set `content-encoding` when we actually compress the body —
+      // this mirrors real server behavior and avoids the misleading-header
+      // footgun where the header would claim an encoding the body doesn't
+      // use (e.g. when a future test passes an unknown encoding value).
       let encoded: Buffer;
       switch (requested) {
         case "br":
           encoded = brotliCompressSync(payload);
+          res.setHeader("content-encoding", "br");
           break;
         case "gzip":
           encoded = gzipSync(payload);
+          res.setHeader("content-encoding", "gzip");
           break;
         case "deflate":
           encoded = deflateSync(payload);
+          res.setHeader("content-encoding", "deflate");
           break;
         default:
           encoded = payload;
       }
-      res.setHeader("content-encoding", requested);
       res.writeHead(200);
       res.end(encoded);
       return;

--- a/test/server.ts
+++ b/test/server.ts
@@ -6,6 +6,7 @@
 import { Buffer } from "node:buffer";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { createSecureServer, type Http2ServerRequest, type Http2ServerResponse } from "node:http2";
+import { brotliCompressSync, deflateSync, gzipSync } from "node:zlib";
 
 // Pre-generated self-signed cert for localhost (valid 10 years, test-only).
 // This is NOT a production credential — it covers only 127.0.0.1/localhost
@@ -104,6 +105,41 @@ function handler(req: Req, res: Res) {
         res.end(JSON.stringify({ echoed: parsed }));
         return;
       }
+    }
+
+    if (parsedUrl.pathname === "/compressed") {
+      // Honor the client's accept-encoding: only compress when the requested
+      // encoding is allowed. This matches what a real fullnode does and lets
+      // tests verify that the client opted out of compression.
+      const requested = parsedUrl.searchParams.get("encoding") ?? "br";
+      const accept = String(req.headers["accept-encoding"] ?? "").toLowerCase();
+      const acceptsRequested = accept === "" || accept.split(",").some((t) => t.trim().split(";")[0] === requested);
+      const payload = Buffer.from(JSON.stringify({ hello: "compressed", encoding: requested }));
+      res.setHeader("content-type", "application/json");
+      res.setHeader("x-accept-encoding-seen", accept || "(unset)");
+      if (!acceptsRequested) {
+        res.writeHead(200);
+        res.end(payload);
+        return;
+      }
+      let encoded: Buffer;
+      switch (requested) {
+        case "br":
+          encoded = brotliCompressSync(payload);
+          break;
+        case "gzip":
+          encoded = gzipSync(payload);
+          break;
+        case "deflate":
+          encoded = deflateSync(payload);
+          break;
+        default:
+          encoded = payload;
+      }
+      res.setHeader("content-encoding", requested);
+      res.writeHead(200);
+      res.end(encoded);
+      return;
     }
 
     if (parsedUrl.pathname === "/bcs") {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "outDir": "./dist",
     "skipLibCheck": true,
     "strict": true,
-    "target": "ES2022"
+    "target": "ES2022",
+    "types": ["node"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

- **Fix Node compression on HTTP/2.** Revert `src/index.node.ts` to `got` — the v3 swap to `undici` via `fetch + dispatcher` silently broke decompression on H1 (and never had it on H2) and dropped response headers including `set-cookie`. Got handles decompression in its own body pipeline, independent of transport, which is the only shape that works against the Aptos fullnode (brotli) and indexer (gzip).
- **Tag this release v4.1.0.** CHANGELOG documents `>=3.0.0 <4.1.0` as broken on Node for compressed responses so users know which versions to avoid.
- **Cross-runtime H2 + decompression coverage.** Every entry point (Node/got, fetch, browser, Bun, Deno) now has parallel tests for HTTP/1.1 vs HTTP/2 and br/gzip/deflate decompression. Stale "Node fetch can't do H2" assertions are replaced with runtime-capability reports (Node 24+ undici and recent Bun both negotiate H2 now).
- **Codecov reporting with an 80% floor.** `pnpm coverage` runs the suite with Node's built-in coverage and emits LCOV; CI uploads to Codecov. `codecov.yml` enforces ≥ 80% project and patch coverage. The suite ships at line 99.65% / branch 93.75% / funcs 100%.
- **Every test asserts something explicit.** Build tests now verify tsc stdout is empty and esbuild output exists; the deno teardown asserts cleanup doesn't throw.

## Why this matters

Versions `>=3.0.0 <4.1.0` return a `string` of raw brotli bytes (or gzip bytes for the indexer) instead of parsed JSON whenever the origin compresses. Downstream code that reads `info.authentication_key` or runs `BigInt(info.sequence_number)` gets `undefined` and `TypeError`. The bug is invisible because `parseJsonSafely` falls back to returning text on `JSON.parse` failure, so callers just see "wrong data."

I empirically verified this against real devnet across all three versions:

| Version | Transport | Fullnode (brotli) | Indexer (gzip, large query) |
|---|---|---|---|
| v2.2.0 | got | ✅ object | ✅ object |
| v3.0.2 | undici | ❌ string (brotli bytes) | ❌ string (gzip bytes) |
| v4.0.0 | undici | ❌ string | ❌ string |
| **v4.1.0 (this PR)** | **got** | **✅ object** | **✅ object** |

## Architecture notes

- The v3+ multi-entry-point architecture (browser / fetch / node / Deno / Bun / edge / workerd / react-native) is preserved. Only `src/index.node.ts` changed shape.
- `got` replaces `undici` as the single runtime dependency of the Node entry. Browser, fetch, Deno, Bun, and React Native entries are unchanged (they use the platform's native `fetch`).
- `tsconfig.json` gains `"types": ["node"]` to make `@types/node` resolution deterministic under pnpm's symlink layout.
- `NODE_TLS_REJECT_UNAUTHORIZED` is now propagated to got's `https.rejectUnauthorized`, since got's H2 transport (`http2-wrapper`) does not inherit the env var on its own.

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes
- [x] `pnpm test` — 87/87 passing
- [x] `pnpm test:build` — 4/4 passing (tsc bundler/nodenext, esbuild node/browser)
- [x] `pnpm coverage` — line 99.65% / branch 93.75% / funcs 100%
- [x] Real devnet smoke test (4/4): fullnode H1+H2 (brotli), indexer H1+H2 (gzip) — see commit message on `cc0a216` for details
- [ ] CI is green
- [ ] Codecov upload succeeds (requires `CODECOV_TOKEN` secret to be set on the repo)

## Notes for reviewer

- `codecov.yml` sets the gate at 80% but the actual coverage is ~99% line, so anyone introducing untested code will get a clear signal.
- The `Codecov upload` step uses `fail_ci_if_error: false` so transient Codecov outages don't block merges — the local coverage report still runs and the test-pass requirement is unaffected.
- If Codecov isn't configured on the repo yet, the upload step is a no-op (the action will skip without the secret). The `CODECOV_TOKEN` repo secret needs to be set for uploads to appear on codecov.io.